### PR TITLE
Introduce `switch` promotion test case and reorder loop promotion passes

### DIFF
--- a/lib/RestructureCFG/BeautifyGHAST.cpp
+++ b/lib/RestructureCFG/BeautifyGHAST.cpp
@@ -1015,16 +1015,6 @@ void beautifyAST(const model::Binary &Model, Function &F, ASTTree &CombedAST) {
   RootNode = matchSwitch(CombedAST, RootNode);
   Dumper.log("after-switch-match");
 
-  // Match dowhile.
-  revng_log(BeautifyLogger, "Matching do-while\n");
-  matchDoWhile(RootNode, CombedAST);
-  Dumper.log("after-match-do-while");
-
-  // Match while.
-  revng_log(BeautifyLogger, "Matching while\n");
-  matchWhile(RootNode, CombedAST);
-  Dumper.log("after-match-while");
-
   // Perform the `SwitchBreak` simplification
   revng_log(BeautifyLogger, "Performing SwitchBreak simplification");
   RootNode = simplifySwitchBreak(CombedAST, RootNode);
@@ -1049,6 +1039,16 @@ void beautifyAST(const model::Binary &Model, Function &F, ASTTree &CombedAST) {
   revng_log(BeautifyLogger, "Removing empty sequence nodes\n");
   RootNode = simplifyAtomicSequence(CombedAST, RootNode);
   Dumper.log("after-empty-sequences-removal");
+
+  // Match dowhile.
+  revng_log(BeautifyLogger, "Matching do-while\n");
+  matchDoWhile(RootNode, CombedAST);
+  Dumper.log("after-match-do-while");
+
+  // Match while.
+  revng_log(BeautifyLogger, "Matching while\n");
+  matchWhile(RootNode, CombedAST);
+  Dumper.log("after-match-while");
 
   // Remove unnecessary scopes under the fallthrough analysis.
   revng_log(BeautifyLogger, "Analyzing fallthrough scopes\n");

--- a/share/revng/test/tests/analysis/Decompilation/x86-64/dual-case-switch.c.filecheck
+++ b/share/revng/test/tests/analysis/Decompilation/x86-64/dual-case-switch.c.filecheck
@@ -1,0 +1,9 @@
+This file is distributed under the MIT License. See LICENSE.md for details.
+
+
+We match the only argument of the f function
+CHECK: {{.*}}64_t f({{.*}}64_t [[ARG0:.*]])
+
+We should have correctly promoted the exit dispatcher switch to an if (switch
+with two cases). The condition of the if should be the argument of the function.
+CHECK: if (({{.*}}32_t) [[ARG0]] == 2)

--- a/share/revng/test/tests/analysis/Decompilation/x86-64/dual-case-switch.c.model.yml
+++ b/share/revng/test/tests/analysis/Decompilation/x86-64/dual-case-switch.c.model.yml
@@ -1,0 +1,5 @@
+---
+#
+# This file is distributed under the MIT License. See LICENSE.md for details.
+#
+Architecture: x86_64


### PR DESCRIPTION
- Introduce a new FileCheck tests for the dual case `switch` to `if` promotion.
- Postpone the beautify loop promotion passes after the `switch` to `if` promotion, in order to catch more promotion opportunities. 