### PR TITLE
Improve `InlineDispatcherSwitch` logic

### DIFF
--- a/include/revng-c/RestructureCFG/ASTNode.h
+++ b/include/revng-c/RestructureCFG/ASTNode.h
@@ -405,6 +405,8 @@ public:
 
   links_container::size_type length() const { return NodeVec.size(); }
 
+  bool empty() const { return NodeVec.empty(); }
+
   ASTNode *getNodeN(links_container::size_type N) const { return NodeVec[N]; }
 
   links_container &getChildVec() { return NodeVec; }

--- a/lib/RestructureCFG/BeautifyGHAST.cpp
+++ b/lib/RestructureCFG/BeautifyGHAST.cpp
@@ -1016,12 +1016,12 @@ void beautifyAST(const model::Binary &Model, Function &F, ASTTree &CombedAST) {
 
   // Perform the `SwitchBreak` simplification
   revng_log(BeautifyLogger, "Performing SwitchBreak simplification");
-  RootNode = simplifySwitchBreak(CombedAST, RootNode);
+  RootNode = simplifySwitchBreak(CombedAST);
   Dumper.log("After-switchbreak-simplify");
 
   // Perform the dispatcher `switch` inlining
   revng_log(BeautifyLogger, "Performing dispatcher switch inlining\n");
-  RootNode = inlineDispatcherSwitch(CombedAST, RootNode);
+  RootNode = inlineDispatcherSwitch(CombedAST);
   Dumper.log("after-dispatcher-switch-inlining");
 
   // Perform the simplification of `switch` with two entries in a `if`

--- a/lib/RestructureCFG/BeautifyGHAST.cpp
+++ b/lib/RestructureCFG/BeautifyGHAST.cpp
@@ -28,6 +28,7 @@
 #include "FallThroughScopeAnalysis.h"
 #include "InlineDispatcherSwitch.h"
 #include "PromoteCallNoReturn.h"
+#include "RemoveDeadCode.h"
 #include "SimplifyCompareNode.h"
 #include "SimplifyDualSwitch.h"
 #include "SimplifyHybridNot.h"
@@ -1023,6 +1024,14 @@ void beautifyAST(const model::Binary &Model, Function &F, ASTTree &CombedAST) {
   revng_log(BeautifyLogger, "Performing dispatcher switch inlining\n");
   RootNode = inlineDispatcherSwitch(CombedAST);
   Dumper.log("after-dispatcher-switch-inlining");
+
+  // Perform the dead code simplification.
+  // We invoke this pass here because the dispatcher case inlining may have
+  // moved around some non local control flow statements like `return`, in such
+  // a way that a dead code simplification step is needed.
+  revng_log(BeautifyLogger, "Performing dead code simplification\n");
+  RootNode = removeDeadCode(Model, CombedAST);
+  Dumper.log("after-dead-code-simplify");
 
   // Perform the simplification of `switch` with two entries in a `if`
   revng_log(BeautifyLogger, "Performing the dual switch simplification\n");

--- a/lib/RestructureCFG/BeautifyGHAST.cpp
+++ b/lib/RestructureCFG/BeautifyGHAST.cpp
@@ -1029,11 +1029,6 @@ void beautifyAST(const model::Binary &Model, Function &F, ASTTree &CombedAST) {
   RootNode = simplifyDualSwitch(CombedAST, RootNode);
   Dumper.log("after-dual-switch-simplify");
 
-  // Fix loop breaks from within switches
-  revng_log(BeautifyLogger, "Fixing loop breaks inside switches\n");
-  SwitchBreaksFixer().run(RootNode, CombedAST);
-  Dumper.log("after-fix-switch-breaks");
-
   // Remove empty sequences.
   revng_log(BeautifyLogger, "Removing empty sequence nodes\n");
   RootNode = simplifyAtomicSequence(CombedAST, RootNode);
@@ -1090,6 +1085,11 @@ void beautifyAST(const model::Binary &Model, Function &F, ASTTree &CombedAST) {
   revng_log(BeautifyLogger, "Performing the implicit return simplification\n");
   simplifyImplicitReturn(CombedAST, RootNode);
   Dumper.log("after-implicit-return-simplify");
+
+  // Fix loop breaks from within switches
+  revng_log(BeautifyLogger, "Fixing loop breaks inside switches\n");
+  SwitchBreaksFixer().run(RootNode, CombedAST);
+  Dumper.log("after-fix-switch-breaks");
 
   // Serialize the collected metrics in the statistics file if necessary
   if (StatsFileStream) {

--- a/lib/RestructureCFG/BeautifyGHAST.cpp
+++ b/lib/RestructureCFG/BeautifyGHAST.cpp
@@ -33,7 +33,6 @@
 #include "SimplifyHybridNot.h"
 #include "SimplifyImplicitStatement.h"
 
-using std::make_unique;
 using std::unique_ptr;
 
 using namespace llvm;

--- a/lib/RestructureCFG/CMakeLists.txt
+++ b/lib/RestructureCFG/CMakeLists.txt
@@ -16,6 +16,7 @@ revng_add_analyses_library(
   MetaRegion.cpp
   PromoteCallNoReturn.cpp
   RegionCFGTree.cpp
+  RemoveDeadCode.cpp
   RestructureCFG.cpp
   SimplifyCompareNode.cpp
   SimplifyDualSwitch.cpp

--- a/lib/RestructureCFG/FallThroughScopeAnalysis.cpp
+++ b/lib/RestructureCFG/FallThroughScopeAnalysis.cpp
@@ -85,16 +85,20 @@ fallThroughScopeImpl(const model::Binary &Model,
   case ASTNode::NK_Scs: {
     ScsNode *Loop = llvm::cast<ScsNode>(Node);
 
-    // The loop node inherits the attribute from the body node of the SCS.
+    // If a body of the loop is present, we recur on the body of the loop
     if (Loop->hasBody()) {
       ASTNode *Body = Loop->getBody();
       FallThroughScopeType BFallThrough = rc_recur
         fallThroughScopeImpl(Model, Body, ResultMap);
       ResultMap[Body] = BFallThrough;
-      rc_return BFallThrough;
-    } else {
-      rc_return FallThroughScopeType::FallThrough;
     }
+
+    // Without a semantic analysis we cannot conclude anything about the
+    // `FallThroughScopeType` of the `ScsNode`. The body of it, if present, will
+    // indeed perform fallthrough even if, the AST composing its body does not
+    // perform fallthrough (which is reasonable, considering that the body of a
+    // loop will end with `break` and `continue` statements)
+    rc_return FallThroughScopeType::FallThrough;
   } break;
   case ASTNode::NK_If: {
     IfNode *If = llvm::cast<IfNode>(Node);

--- a/lib/RestructureCFG/FallThroughScopeAnalysis.cpp
+++ b/lib/RestructureCFG/FallThroughScopeAnalysis.cpp
@@ -153,11 +153,13 @@ fallThroughScopeImpl(const model::Binary &Model,
     //    result, in cases where the `SwitchNode` does not have the `default`
     //    case, but it however covers all the possible values for the condition
     //    in the enumeration of the cases.
-    // 2) If we have a dispatcher `SwitchNode`, we have a guarantee by
-    //    construction, that all the `case`s span over the possible values.
-    //    Therefore, we can perform the analysis as if the `SwitchNode` had the
-    //    `default`.
-    if (not Switch->getCondition() or Switch->hasDefault()) {
+    // 2) Even when encountering a dispatcher `SwitchNode`, we can compute the
+    //    analysis result only if no `default` `case` is present. Indeed,
+    //    previous beautifications may have removed some of the `case`s, thus
+    //    invalidating the assumption, true at the beginning of the beautify
+    //    pipeline, that the `case`s of a dispatcher `switch` span over all the
+    //    possible values of the state variable.
+    if (Switch->hasDefault()) {
       rc_return AllFallThrough;
     } else {
       rc_return FallThroughScopeType::FallThrough;

--- a/lib/RestructureCFG/FallThroughScopeAnalysis.cpp
+++ b/lib/RestructureCFG/FallThroughScopeAnalysis.cpp
@@ -227,7 +227,10 @@ fallThroughScopeImpl(const model::Binary &Model,
     rc_return FallThroughScopeType::FallThrough;
   } break;
   case ASTNode::NK_SwitchBreak: {
-    rc_return FallThroughScopeType::SwitchBreak;
+
+    // `The `SwitchBreak` represents the fact that we fallthrough from the
+    // switch out
+    rc_return FallThroughScopeType::FallThrough;
   } break;
   case ASTNode::NK_Continue: {
     rc_return FallThroughScopeType::Continue;

--- a/lib/RestructureCFG/FallThroughScopeAnalysis.h
+++ b/lib/RestructureCFG/FallThroughScopeAnalysis.h
@@ -21,7 +21,6 @@ enum class FallThroughScopeType {
   Return,
   Continue,
   LoopBreak,
-  SwitchBreak,
 };
 
 using FallThroughScopeTypeMap = std::map<const ASTNode *, FallThroughScopeType>;

--- a/lib/RestructureCFG/InlineDispatcherSwitch.cpp
+++ b/lib/RestructureCFG/InlineDispatcherSwitch.cpp
@@ -221,6 +221,15 @@ static RecursiveCoroutine<ASTNode *> addToDispatcherSet(ASTTree &AST,
   rc_return Node;
 }
 
+/// Wrapper helper used to remove a specific `SetNode` from the body of a loop,
+/// reusing the code of the `addToDispatcherSet` helper
+static void removeDispatcherSet(ASTTree &AST, ASTNode *Node, ASTNode *Set) {
+
+  // We perform the `SetNode` by instructing `addToDispatcherSet` to inline a
+  // `nullptr`, and to remove the original `SetNode`
+  addToDispatcherSet(AST, Node, nullptr, Set, true);
+}
+
 static bool isDispatcherIf(ASTNode *If) {
   const ExprNode *E = llvm::cast<IfNode>(If)->getCondExpr();
   using NodeKind = ExprNode::NodeKind;
@@ -771,7 +780,10 @@ ASTNode *inlineDispatcherSwitch(ASTTree &AST, ASTNode *RootNode) {
   return RootNode;
 }
 
-static RecursiveCoroutine<ASTNode *> simplifySwitchBreakImpl(ASTNode *Node) {
+static RecursiveCoroutine<ASTNode *>
+simplifySwitchBreakImpl(ASTTree &AST,
+                        ASTNode *Node,
+                        const LoopDispatcherMap &LoopDispatcherMap) {
   switch (Node->getKind()) {
   case ASTNode::NK_List: {
     SequenceNode *Seq = llvm::cast<SequenceNode>(Node);
@@ -779,7 +791,7 @@ static RecursiveCoroutine<ASTNode *> simplifySwitchBreakImpl(ASTNode *Node) {
     // In place of a sequence node, we just need to inspect all the nodes in the
     // sequence
     for (ASTNode *&N : Seq->nodes()) {
-      N = rc_recur simplifySwitchBreakImpl(N);
+      N = rc_recur simplifySwitchBreakImpl(AST, N, LoopDispatcherMap);
     }
 
     // In this beautify, it may be that a dispatcher switch is completely
@@ -795,7 +807,9 @@ static RecursiveCoroutine<ASTNode *> simplifySwitchBreakImpl(ASTNode *Node) {
     // Inspect loop nodes
     if (Scs->hasBody()) {
       ASTNode *Body = Scs->getBody();
-      ASTNode *NewBody = rc_recur simplifySwitchBreakImpl(Body);
+      ASTNode *NewBody = rc_recur simplifySwitchBreakImpl(AST,
+                                                          Body,
+                                                          LoopDispatcherMap);
       Scs->setBody(NewBody);
     }
 
@@ -806,12 +820,16 @@ static RecursiveCoroutine<ASTNode *> simplifySwitchBreakImpl(ASTNode *Node) {
     // Inspect the `then` and `else` branches
     if (If->hasThen()) {
       ASTNode *Then = If->getThen();
-      ASTNode *NewThen = rc_recur simplifySwitchBreakImpl(Then);
+      ASTNode *NewThen = rc_recur simplifySwitchBreakImpl(AST,
+                                                          Then,
+                                                          LoopDispatcherMap);
       If->setThen(NewThen);
     }
     if (If->hasElse()) {
       ASTNode *Else = If->getElse();
-      ASTNode *NewElse = rc_recur simplifySwitchBreakImpl(Else);
+      ASTNode *NewElse = rc_recur simplifySwitchBreakImpl(AST,
+                                                          Else,
+                                                          LoopDispatcherMap);
       If->setElse(NewElse);
     }
   } break;
@@ -824,8 +842,8 @@ static RecursiveCoroutine<ASTNode *> simplifySwitchBreakImpl(ASTNode *Node) {
     for (auto &Group : llvm::enumerate(Switch->cases())) {
       unsigned Index = Group.index();
       auto &LabelCasePair = Group.value();
-      LabelCasePair
-        .second = rc_recur simplifySwitchBreakImpl(LabelCasePair.second);
+      LabelCasePair.second = rc_recur
+        simplifySwitchBreakImpl(AST, LabelCasePair.second, LoopDispatcherMap);
 
       if (LabelCasePair.second == nullptr) {
         ToRemoveCaseIndex.push_back(Index);
@@ -854,6 +872,9 @@ static RecursiveCoroutine<ASTNode *> simplifySwitchBreakImpl(ASTNode *Node) {
       // Search for cases that are composed by a single `SwitchBreak` node
       llvm::SmallVector<size_t> ToRemoveCaseIndex;
 
+      // Save the `LabelSet`s associated to the removed `case`s
+      llvm::SmallSet<size_t, 1> RemovedLabels;
+
       // We do not need to skip the `default` case here, because there is no
       // `default` in first place
       for (auto &Group : llvm::enumerate(Switch->cases())) {
@@ -862,11 +883,41 @@ static RecursiveCoroutine<ASTNode *> simplifySwitchBreakImpl(ASTNode *Node) {
 
         if (llvm::isa<SwitchBreakNode>(Case)) {
           ToRemoveCaseIndex.push_back(Index);
+
+          // If we are removing an atomic `Label`, we save it for later removal
+          // of the associated `SetNode`. We do not remove the `SetNode`s
+          // associated to multiple `Label`s `case`s, because that would not be
+          // correct. The removal of the associated `SetNode` should be
+          // performed only in correspondence of the `case`s containing the
+          // atomic `Label`.
+          if (LabelSet.size() == 1) {
+            RemovedLabels.insert(*LabelSet.begin());
+          }
         }
       }
 
       for (auto ToRemoveCase : llvm::reverse(ToRemoveCaseIndex)) {
         Switch->removeCaseN(ToRemoveCase);
+      }
+
+      // In case we are simplifying the `SwitchBreak` associated to an exit
+      // dispatcher, we also need to remove the corresponding `SetNode`s
+      using DispatcherKind = typename SwitchNode::DispatcherKind;
+      if (not Switch->getCondition()
+          and Switch->getDispatcherKind() == DispatcherKind::DK_Exit) {
+
+        // Precompute how many `SetNode`s are present in the related `Scs`
+        auto &[RelatedLoop, RemoveSetNode] = LoopDispatcherMap.at(Switch);
+        SetNodeCounterMap SetCounterMap;
+        countSetNodeInLoop(RelatedLoop->getBody(), SetCounterMap);
+
+        // Remove the `SetNode`s associated to the removed `Label`s
+        for (auto &Label : RemovedLabels) {
+          auto &Sets = SetCounterMap.at(Label);
+          for (auto *Set : Sets) {
+            removeDispatcherSet(AST, RelatedLoop->getBody(), Set);
+          }
+        }
       }
     }
 
@@ -896,8 +947,11 @@ static RecursiveCoroutine<ASTNode *> simplifySwitchBreakImpl(ASTNode *Node) {
 /// `case`.
 ASTNode *simplifySwitchBreak(ASTTree &AST, ASTNode *RootNode) {
 
+  // Compute the loop -> dispatcher switch correspondence
+  LoopDispatcherMap LoopDispatcherMap = computeLoopDispatcher(AST);
+
   // Simplify away `SwitchBreakNode`s from `switch`es
-  RootNode = simplifySwitchBreakImpl(RootNode);
+  RootNode = simplifySwitchBreakImpl(AST, RootNode, LoopDispatcherMap);
   AST.setRoot(RootNode);
 
   return RootNode;

--- a/lib/RestructureCFG/InlineDispatcherSwitch.cpp
+++ b/lib/RestructureCFG/InlineDispatcherSwitch.cpp
@@ -619,18 +619,9 @@ inlineDispatcherSwitchImpl(ASTTree &AST,
           auto &Sets = SetCounterMap.at(Label);
           if (llvm::isa<SwitchBreakNode>(Case)) {
 
-            // If the body of the case is composed by a single `SwitchBreakNode`
-            // node, we can remove it, by virtually inlining a `nullptr` in the
-            // place of all the corresponding `SetNode`s (we can do it multiple
-            // times since we are not duplicating code here)
-            for (SetNode *Set : Sets) {
-              addToDispatcherSet(AST,
-                                 RelatedLoop->getBody(),
-                                 nullptr,
-                                 Set,
-                                 RemoveSetNode);
-            }
-            ToRemoveCaseIndex.insert(Index);
+            // The superfluous `SwitchBreak` removal should have been already
+            // performed in the `simplifySwitchBreak` phase
+            revng_abort();
           } else if (Sets.size() == 1
                      and (not needsLoopVar(RelatedLoop)
                           or not containsSet(Case))) {

--- a/lib/RestructureCFG/InlineDispatcherSwitch.cpp
+++ b/lib/RestructureCFG/InlineDispatcherSwitch.cpp
@@ -767,12 +767,14 @@ inlineDispatcherSwitchImpl(ASTTree &AST,
   rc_return Node;
 }
 
-ASTNode *inlineDispatcherSwitch(ASTTree &AST, ASTNode *RootNode) {
+ASTNode *inlineDispatcherSwitch(ASTTree &AST) {
 
   // Compute the loop -> dispatcher switch correspondence
   LoopDispatcherMap LoopDispatcherMap = computeLoopDispatcher(AST);
 
-  RootNode = inlineDispatcherSwitchImpl(AST, RootNode, LoopDispatcherMap);
+  ASTNode *RootNode = inlineDispatcherSwitchImpl(AST,
+                                                 AST.getRoot(),
+                                                 LoopDispatcherMap);
 
   // Update the root field of the AST
   AST.setRoot(RootNode);
@@ -945,13 +947,15 @@ simplifySwitchBreakImpl(ASTTree &AST,
 /// are superfluous. We consider such nodes as `SwitchBreakNode`s that compose
 /// the entirety of a `case` of a `switch`, which must not have a `default`
 /// `case`.
-ASTNode *simplifySwitchBreak(ASTTree &AST, ASTNode *RootNode) {
+ASTNode *simplifySwitchBreak(ASTTree &AST) {
 
   // Compute the loop -> dispatcher switch correspondence
   LoopDispatcherMap LoopDispatcherMap = computeLoopDispatcher(AST);
 
   // Simplify away `SwitchBreakNode`s from `switch`es
-  RootNode = simplifySwitchBreakImpl(AST, RootNode, LoopDispatcherMap);
+  ASTNode *RootNode = simplifySwitchBreakImpl(AST,
+                                              AST.getRoot(),
+                                              LoopDispatcherMap);
   AST.setRoot(RootNode);
 
   return RootNode;

--- a/lib/RestructureCFG/InlineDispatcherSwitch.h
+++ b/lib/RestructureCFG/InlineDispatcherSwitch.h
@@ -10,6 +10,6 @@
 class ASTNode;
 class ASTTree;
 
-extern ASTNode *inlineDispatcherSwitch(ASTTree &AST, ASTNode *RootNode);
+extern ASTNode *inlineDispatcherSwitch(ASTTree &AST);
 
-extern ASTNode *simplifySwitchBreak(ASTTree &AST, ASTNode *RootNode);
+extern ASTNode *simplifySwitchBreak(ASTTree &AST);

--- a/lib/RestructureCFG/PromoteCallNoReturn.cpp
+++ b/lib/RestructureCFG/PromoteCallNoReturn.cpp
@@ -30,8 +30,7 @@ static bool isPreferredAsFallThrough(FallThroughScopeType Element) {
   switch (Element) {
   case FallThroughScopeType::Return:
   case FallThroughScopeType::Continue:
-  case FallThroughScopeType::LoopBreak:
-  case FallThroughScopeType::SwitchBreak: {
+  case FallThroughScopeType::LoopBreak: {
     return true;
   } break;
   case FallThroughScopeType::FallThrough:

--- a/lib/RestructureCFG/RemoveDeadCode.cpp
+++ b/lib/RestructureCFG/RemoveDeadCode.cpp
@@ -1,0 +1,142 @@
+/// \file RemoveDeadCode.cpp
+/// Beautification pass to simplify dead code in the AST representation
+///
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "revng/ADT/RecursiveCoroutine.h"
+#include "revng/Support/Assert.h"
+
+#include "revng-c/RestructureCFG/ASTNode.h"
+#include "revng-c/RestructureCFG/ASTTree.h"
+
+#include "FallThroughScopeAnalysis.h"
+#include "RemoveDeadCode.h"
+
+static RecursiveCoroutine<ASTNode *>
+removeDeadCodeImpl(ASTNode *Node,
+                   const FallThroughScopeTypeMap &FallThroughScopeMap) {
+  switch (Node->getKind()) {
+  case ASTNode::NK_List: {
+    SequenceNode *Seq = llvm::cast<SequenceNode>(Node);
+
+    // In place of a sequence node, we just need to inspect all the nodes in the
+    // sequence
+    bool ShouldSimplify = false;
+    for (ASTNode *&N : Seq->nodes()) {
+      if (not ShouldSimplify) {
+
+        // Compute the `FallThrough information after each `SequencenNode` is
+        // processed, and mark the code alive from that node in the sequence on
+        // only if we have fallthrough
+        N = rc_recur removeDeadCodeImpl(N, FallThroughScopeMap);
+        FallThroughScopeType
+          FallThroughType = FallThroughScopeType::FallThrough;
+        ShouldSimplify = FallThroughScopeMap.at(N) != FallThroughType;
+      } else {
+        N = nullptr;
+      }
+    }
+
+    // In this beautify, it may be that a dispatcher switch is completely
+    // removed, therefore leaving a `nullptr` in a `SequenceNode`. We remove all
+    // these `nullptr` from the `SequenceNode` after the processing has taken
+    // place
+    Seq->removeNode(nullptr);
+
+    // This simplify should never leave an empty `SequenceNode` (at the very
+    // least, the first nody of the `SequenceNode`, which is the one not
+    // performing fallthrough, should be kept alive). Later on, in the beautify
+    // pass "pipeline", we have an invocation of the `simplifyAtomicSequence`
+    // routine aimed to unwrap unitary `SequenceNode`s.
+    revng_assert(not Seq->empty());
+  } break;
+  case ASTNode::NK_Scs: {
+    ScsNode *Scs = llvm::cast<ScsNode>(Node);
+
+    // Inspect loop nodes
+    if (Scs->hasBody()) {
+      ASTNode *Body = Scs->getBody();
+      ASTNode *NewBody = rc_recur removeDeadCodeImpl(Body, FallThroughScopeMap);
+      Scs->setBody(NewBody);
+    }
+
+  } break;
+  case ASTNode::NK_If: {
+    IfNode *If = llvm::cast<IfNode>(Node);
+
+    // Inspect the `then` and `else` branches
+    if (If->hasThen()) {
+      ASTNode *Then = If->getThen();
+      ASTNode *NewThen = rc_recur removeDeadCodeImpl(Then, FallThroughScopeMap);
+      If->setThen(NewThen);
+    }
+    if (If->hasElse()) {
+      ASTNode *Else = If->getElse();
+      ASTNode *NewElse = rc_recur removeDeadCodeImpl(Else, FallThroughScopeMap);
+      If->setElse(NewElse);
+    }
+  } break;
+  case ASTNode::NK_Switch: {
+    auto *Switch = llvm::cast<SwitchNode>(Node);
+
+    // First of all, we recursively process the `case` nodes contained in the
+    // `switch` in order to process the inner portion of the AST
+    llvm::SmallVector<size_t> ToRemoveCaseIndex;
+    for (auto &Group : llvm::enumerate(Switch->cases())) {
+      unsigned Index = Group.index();
+      auto &LabelCasePair = Group.value();
+      LabelCasePair.second = rc_recur removeDeadCodeImpl(LabelCasePair.second,
+                                                         FallThroughScopeMap);
+
+      if (LabelCasePair.second == nullptr) {
+        ToRemoveCaseIndex.push_back(Index);
+      }
+    }
+
+    for (auto ToRemoveCase : llvm::reverse(ToRemoveCaseIndex)) {
+      Switch->removeCaseN(ToRemoveCase);
+    }
+  } break;
+  case ASTNode::NK_Code:
+  case ASTNode::NK_Set:
+  case ASTNode::NK_SwitchBreak:
+  case ASTNode::NK_Continue:
+  case ASTNode::NK_Break:
+    // Do nothing
+    break;
+  default:
+    revng_unreachable();
+  }
+
+  rc_return Node;
+}
+
+/// This simplification routine mimics a dead code elimination pass. Basically,
+/// when we have a `SequenceNode`, and we find a node sporting the
+/// `nofallthrough` beahvior, we can remove all the following nodes in the
+/// `SequenceNode`.
+/// A practical example of why this may happen: after the inlining of dispatcher
+/// `case`s, if a `return` statement is moved into an inner loop in place of a
+/// `SetNode`, it may be that a following `break` statement, and therefore the
+/// `break` can be simplified away.
+ASTNode *removeDeadCode(const model::Binary &Model, ASTTree &AST) {
+  ASTNode *RootNode = AST.getRoot();
+
+  // Pre-compute the `FallThroughScopeType` before the `SuperfluousNonLocalCF`
+  // simplify is performed. This information is useful in order to decide
+  // whether we remove some statements that after the `case` inlining are
+  // preceded by `return` statements.
+  FallThroughScopeTypeMap
+    FallThroughScopeMap = computeFallThroughScope(Model, RootNode);
+
+  // Perform the `SuperfluousNonLocalCF` simplification pass
+  RootNode = removeDeadCodeImpl(RootNode, FallThroughScopeMap);
+
+  // Update the root field of the AST
+  AST.setRoot(RootNode);
+
+  return RootNode;
+}

--- a/lib/RestructureCFG/RemoveDeadCode.h
+++ b/lib/RestructureCFG/RemoveDeadCode.h
@@ -1,0 +1,13 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "FallThroughScopeAnalysis.h"
+
+// Forward declarations
+class ASTNode;
+class ASTTree;
+
+extern ASTNode *removeDeadCode(const model::Binary &Model, ASTTree &AST);

--- a/lib/RestructureCFG/RestructureCFG.cpp
+++ b/lib/RestructureCFG/RestructureCFG.cpp
@@ -38,7 +38,6 @@ using namespace llvm::cl;
 
 using std::pair;
 using std::string;
-using std::to_string;
 
 // TODO: Move the initialization of the logger here from "Utils.h"
 // Debug logger.


### PR DESCRIPTION
We introduce the following improvements for the `InlineDispatcherSwitch` routine:
- We do not inline `case`s which contain a `break` or `continue` statements. Moving such kind of statement would indeed break the semantics.
- Simplify redundant _non local control flow_ statements: i.e., when we inline a `return` statement, we remove redundant following `break`s and `continue`s.
- We remove the associated `SetNode`s when simplifying `SwitchBreak` statements for exit dispatchers.

Additionally, we remove some dead code and reorder the `SwitchBreaksFixer` pass.