### PR TITLE
Fix licence headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 cmake_minimum_required(VERSION 3.15.0)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 install_pattern("*.h")

--- a/include/revng-c/Backend/DecompileFunction.h
+++ b/include/revng-c/Backend/DecompileFunction.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/Module.h"

--- a/include/revng-c/Backend/DecompilePipe.h
+++ b/include/revng-c/Backend/DecompilePipe.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <array>

--- a/include/revng-c/Backend/DecompileToSingleFile.h
+++ b/include/revng-c/Backend/DecompileToSingleFile.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Support/raw_ostream.h"

--- a/include/revng-c/Backend/DecompileToSingleFilePipe.h
+++ b/include/revng-c/Backend/DecompileToSingleFilePipe.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <array>

--- a/include/revng-c/Backend/DecompiledCCodeIndentation.h
+++ b/include/revng-c/Backend/DecompiledCCodeIndentation.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 inline constexpr int DecompiledCCodeIndentation = 2;

--- a/include/revng-c/DataLayoutAnalysis/DLALayouts.h
+++ b/include/revng-c/DataLayoutAnalysis/DLALayouts.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/include/revng-c/DataLayoutAnalysis/DLAPass.h
+++ b/include/revng-c/DataLayoutAnalysis/DLAPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <memory>

--- a/include/revng-c/DataLayoutAnalysis/DLATypeSystem.h
+++ b/include/revng-c/DataLayoutAnalysis/DLATypeSystem.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <compare>

--- a/include/revng-c/HeadersGeneration/HelpersToHeader.h
+++ b/include/revng-c/HeadersGeneration/HelpersToHeader.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 namespace llvm {

--- a/include/revng-c/HeadersGeneration/HelpersToHeaderPipe.h
+++ b/include/revng-c/HeadersGeneration/HelpersToHeaderPipe.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <array>

--- a/include/revng-c/HeadersGeneration/ModelToHeader.h
+++ b/include/revng-c/HeadersGeneration/ModelToHeader.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <set>

--- a/include/revng-c/HeadersGeneration/ModelToHeaderPipe.h
+++ b/include/revng-c/HeadersGeneration/ModelToHeaderPipe.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <array>

--- a/include/revng-c/HeadersGeneration/ModelTypeDefinition.h
+++ b/include/revng-c/HeadersGeneration/ModelTypeDefinition.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Model/Binary.h"

--- a/include/revng-c/HeadersGeneration/ModelTypeDefinitionPipe.h
+++ b/include/revng-c/HeadersGeneration/ModelTypeDefinitionPipe.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <array>

--- a/include/revng-c/InitModelTypes/InitModelTypes.h
+++ b/include/revng-c/InitModelTypes/InitModelTypes.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <map>

--- a/include/revng-c/Pipes/Kinds.h
+++ b/include/revng-c/Pipes/Kinds.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Pipes/Kinds.h"

--- a/include/revng-c/Pipes/Ranks.h
+++ b/include/revng-c/Pipes/Ranks.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Model/Argument.h"

--- a/include/revng-c/PromoteStackPointer/CleanupStackSizeMarkersPass.h
+++ b/include/revng-c/PromoteStackPointer/CleanupStackSizeMarkersPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/include/revng-c/PromoteStackPointer/ComputeStackAccessesBoundsPass.h
+++ b/include/revng-c/PromoteStackPointer/ComputeStackAccessesBoundsPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/include/revng-c/PromoteStackPointer/DetectStackSizePass.h
+++ b/include/revng-c/PromoteStackPointer/DetectStackSizePass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/include/revng-c/PromoteStackPointer/InjectStackSizeProbesAtCallSitesPass.h
+++ b/include/revng-c/PromoteStackPointer/InjectStackSizeProbesAtCallSitesPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/include/revng-c/PromoteStackPointer/InstrumentStackAccessesPass.h
+++ b/include/revng-c/PromoteStackPointer/InstrumentStackAccessesPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/include/revng-c/PromoteStackPointer/PromoteStackPointerPass.h
+++ b/include/revng-c/PromoteStackPointer/PromoteStackPointerPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Support/TaggedFunctionPass.h"

--- a/include/revng-c/PromoteStackPointer/RemoveStackAlignmentPass.h
+++ b/include/revng-c/PromoteStackPointer/RemoveStackAlignmentPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/include/revng-c/PromoteStackPointer/SegregateStackAccessesPass.h
+++ b/include/revng-c/PromoteStackPointer/SegregateStackAccessesPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/include/revng-c/RemoveExtractValues/RemoveExtractValuesPass.h
+++ b/include/revng-c/RemoveExtractValues/RemoveExtractValuesPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/include/revng-c/RestructureCFG/ASTNode.h
+++ b/include/revng-c/RestructureCFG/ASTNode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/include/revng-c/RestructureCFG/ASTNodeUtils.h
+++ b/include/revng-c/RestructureCFG/ASTNodeUtils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 class ASTNode;

--- a/include/revng-c/RestructureCFG/ASTTree.h
+++ b/include/revng-c/RestructureCFG/ASTTree.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/include/revng-c/RestructureCFG/BasicBlockNode.h
+++ b/include/revng-c/RestructureCFG/BasicBlockNode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/include/revng-c/RestructureCFG/BasicBlockNodeBB.h
+++ b/include/revng-c/RestructureCFG/BasicBlockNodeBB.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 // Forward declarations

--- a/include/revng-c/RestructureCFG/BasicBlockNodeImpl.h
+++ b/include/revng-c/RestructureCFG/BasicBlockNodeImpl.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/include/revng-c/RestructureCFG/BeautifyGHAST.h
+++ b/include/revng-c/RestructureCFG/BeautifyGHAST.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 namespace llvm {

--- a/include/revng-c/RestructureCFG/ExprNode.h
+++ b/include/revng-c/RestructureCFG/ExprNode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/include/revng-c/RestructureCFG/GenerateAst.h
+++ b/include/revng-c/RestructureCFG/GenerateAst.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/include/revng-c/RestructureCFG/MetaRegion.h
+++ b/include/revng-c/RestructureCFG/MetaRegion.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <memory>

--- a/include/revng-c/RestructureCFG/MetaRegionBB.h
+++ b/include/revng-c/RestructureCFG/MetaRegionBB.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 // Forward declarations

--- a/include/revng-c/RestructureCFG/MetaRegionImpl.h
+++ b/include/revng-c/RestructureCFG/MetaRegionImpl.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <memory>

--- a/include/revng-c/RestructureCFG/RegionCFGTree.h
+++ b/include/revng-c/RestructureCFG/RegionCFGTree.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/include/revng-c/RestructureCFG/RegionCFGTreeBB.h
+++ b/include/revng-c/RestructureCFG/RegionCFGTreeBB.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/include/revng-c/RestructureCFG/RegionCFGTreeImpl.h
+++ b/include/revng-c/RestructureCFG/RegionCFGTreeImpl.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/include/revng-c/RestructureCFG/RestructureCFG.h
+++ b/include/revng-c/RestructureCFG/RestructureCFG.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/Function.h"

--- a/include/revng-c/RestructureCFG/Utils.h
+++ b/include/revng-c/RestructureCFG/Utils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/include/revng-c/Support/DecompilationHelpers.h
+++ b/include/revng-c/Support/DecompilationHelpers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/Attributes.h"

--- a/include/revng-c/Support/FunctionTags.h
+++ b/include/revng-c/Support/FunctionTags.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <compare>

--- a/include/revng-c/Support/IRHelpers.h
+++ b/include/revng-c/Support/IRHelpers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <optional>

--- a/include/revng-c/Support/Mangling.h
+++ b/include/revng-c/Support/Mangling.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cctype>

--- a/include/revng-c/Support/ModelHelpers.h
+++ b/include/revng-c/Support/ModelHelpers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/STLExtras.h"

--- a/include/revng-c/Support/PTML.h
+++ b/include/revng-c/Support/PTML.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/PTML/Constants.h"

--- a/include/revng-c/Support/PTMLC.h
+++ b/include/revng-c/Support/PTMLC.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <type_traits>

--- a/include/revng-c/Support/TokenDefinitions.h
+++ b/include/revng-c/Support/TokenDefinitions.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/SmallString.h"

--- a/include/revng-c/TypeNames/LLVMTypeNames.h
+++ b/include/revng-c/TypeNames/LLVMTypeNames.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <string>

--- a/include/revng-c/TypeNames/ModelToPTMLTypeHelpers.h
+++ b/include/revng-c/TypeNames/ModelToPTMLTypeHelpers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <unordered_map>

--- a/include/revng-c/TypeNames/ModelTypeNames.h
+++ b/include/revng-c/TypeNames/ModelTypeNames.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/SmallString.h"

--- a/include/revng-c/mlir/Dialect/Clift/IR/CMakeLists.txt
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 # This policy mimics the behavior set in `CMakePolicy.cmake` in the official

--- a/include/revng-c/mlir/Dialect/Clift/IR/Clift.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/Clift.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "mlir/IR/Dialect.h"

--- a/include/revng-c/mlir/Dialect/Clift/IR/Clift.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/Clift.td
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #ifndef MLIR_CLIFT

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "mlir/IR/AttributeSupport.h"

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.td
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #ifndef MLIR_CLIFT_ATTRIBUTE

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftEnums.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftEnums.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "mlir/IR/BuiltinTypes.h"

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftEnums.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftEnums.td
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 include "mlir/IR/EnumAttr.td"

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng-c/mlir/Dialect/Clift/IR/Clift.h"

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #ifndef MLIR_CLIFT_INTERFACE

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftOps.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftOps.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "mlir/IR/OpDefinition.h"

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftOps.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftOps.td
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #ifndef MLIR_CLIFT_OPS

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftStorage.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftStorage.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "mlir/IR/AttributeSupport.h"

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftTraits.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftTraits.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "mlir/IR/OpDefinition.h"

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/TypeSwitch.h"

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 // Include the definition of the necessary tablegen constructs for defining our

--- a/lib/Backend/ALAPVariableDeclaration.cpp
+++ b/lib/Backend/ALAPVariableDeclaration.cpp
@@ -4,7 +4,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <list>

--- a/lib/Backend/ALAPVariableDeclaration.h
+++ b/lib/Backend/ALAPVariableDeclaration.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <unordered_map>

--- a/lib/Backend/CMakeLists.txt
+++ b/lib/Backend/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(

--- a/lib/Backend/DecompileFunction.cpp
+++ b/lib/Backend/DecompileFunction.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <utility>

--- a/lib/Backend/DecompilePipe.cpp
+++ b/lib/Backend/DecompilePipe.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Model/Binary.h"

--- a/lib/Backend/DecompileToSingleFile.cpp
+++ b/lib/Backend/DecompileToSingleFile.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Support/raw_ostream.h"

--- a/lib/Backend/DecompileToSingleFilePipe.cpp
+++ b/lib/Backend/DecompileToSingleFilePipe.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Pipeline/AllRegistries.h"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 add_subdirectory(Backend)

--- a/lib/Canonicalize/CMakeLists.txt
+++ b/lib/Canonicalize/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(

--- a/lib/Canonicalize/ExitSSAPass.cpp
+++ b/lib/Canonicalize/ExitSSAPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/Canonicalize/FoldModelGEP.cpp
+++ b/lib/Canonicalize/FoldModelGEP.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/PostOrderIterator.h"

--- a/lib/Canonicalize/HoistStructPhis.cpp
+++ b/lib/Canonicalize/HoistStructPhis.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Passes/PassBuilder.h"

--- a/lib/Canonicalize/LoopRewriteWithCanonicalIV.cpp
+++ b/lib/Canonicalize/LoopRewriteWithCanonicalIV.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Analysis/IVUsers.h"

--- a/lib/Canonicalize/MakeLocalVariables.cpp
+++ b/lib/Canonicalize/MakeLocalVariables.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/DerivedTypes.h"

--- a/lib/Canonicalize/MakeModelCastPass.cpp
+++ b/lib/Canonicalize/MakeModelCastPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/Canonicalize/MakeModelGEPPass.cpp
+++ b/lib/Canonicalize/MakeModelGEPPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <compare>

--- a/lib/Canonicalize/OperatorPrecedenceResolutionPass.cpp
+++ b/lib/Canonicalize/OperatorPrecedenceResolutionPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <array>

--- a/lib/Canonicalize/PeepholeOptimizationPass.cpp
+++ b/lib/Canonicalize/PeepholeOptimizationPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/DepthFirstIterator.h"

--- a/lib/Canonicalize/PrepareLLVMIRForMLIR.cpp
+++ b/lib/Canonicalize/PrepareLLVMIRForMLIR.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/DIBuilder.h"

--- a/lib/Canonicalize/PrettyIntFormattingPass.cpp
+++ b/lib/Canonicalize/PrettyIntFormattingPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <array>

--- a/lib/Canonicalize/RemoveLLVMAssumeCallsPass.cpp
+++ b/lib/Canonicalize/RemoveLLVMAssumeCallsPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/SmallVector.h"

--- a/lib/Canonicalize/RemoveLoadStore.cpp
+++ b/lib/Canonicalize/RemoveLoadStore.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/DerivedTypes.h"

--- a/lib/Canonicalize/RemovePointerCasts.cpp
+++ b/lib/Canonicalize/RemovePointerCasts.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/Canonicalize/SplitOverflowIntrinsicsPass.cpp
+++ b/lib/Canonicalize/SplitOverflowIntrinsicsPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/STLExtras.h"

--- a/lib/Canonicalize/SwitchToStatements.cpp
+++ b/lib/Canonicalize/SwitchToStatements.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <compare>

--- a/lib/Canonicalize/TernaryReductionPass.cpp
+++ b/lib/Canonicalize/TernaryReductionPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/Constants.h"

--- a/lib/Canonicalize/TwosComplementArithmeticNormalizationPass.cpp
+++ b/lib/Canonicalize/TwosComplementArithmeticNormalizationPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/Constants.h"

--- a/lib/DataLayoutAnalysis/Backend/DLAMakeModelTypes.cpp
+++ b/lib/DataLayoutAnalysis/Backend/DLAMakeModelTypes.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/DataLayoutAnalysis/Backend/DLAMakeModelTypes.h
+++ b/lib/DataLayoutAnalysis/Backend/DLAMakeModelTypes.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/EarlyFunctionAnalysis/FunctionMetadataCache.h"

--- a/lib/DataLayoutAnalysis/Backend/DLAUpdateModelTypes.cpp
+++ b/lib/DataLayoutAnalysis/Backend/DLAUpdateModelTypes.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/DataLayoutAnalysis/CMakeLists.txt
+++ b/lib/DataLayoutAnalysis/CMakeLists.txt
@@ -1,4 +1,4 @@
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(

--- a/lib/DataLayoutAnalysis/DLAPass.cpp
+++ b/lib/DataLayoutAnalysis/DLAPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Model/LoadModelPass.h"

--- a/lib/DataLayoutAnalysis/DLATypeSystem.cpp
+++ b/lib/DataLayoutAnalysis/DLATypeSystem.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/DataLayoutAnalysis/Frontend/DLACreateInterProceduralTypes.cpp
+++ b/lib/DataLayoutAnalysis/Frontend/DLACreateInterProceduralTypes.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/DerivedTypes.h"

--- a/lib/DataLayoutAnalysis/Frontend/DLACreateIntraProceduralTypes.cpp
+++ b/lib/DataLayoutAnalysis/Frontend/DLACreateIntraProceduralTypes.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <optional>

--- a/lib/DataLayoutAnalysis/Frontend/DLATypeSystemBuilder.cpp
+++ b/lib/DataLayoutAnalysis/Frontend/DLATypeSystemBuilder.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/Argument.h"

--- a/lib/DataLayoutAnalysis/Frontend/DLATypeSystemBuilder.h
+++ b/lib/DataLayoutAnalysis/Frontend/DLATypeSystemBuilder.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/lib/DataLayoutAnalysis/Frontend/SCEVBaseAddressExplorer.cpp
+++ b/lib/DataLayoutAnalysis/Frontend/SCEVBaseAddressExplorer.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Analysis/ScalarEvolution.h"

--- a/lib/DataLayoutAnalysis/Frontend/SCEVBaseAddressExplorer.h
+++ b/lib/DataLayoutAnalysis/Frontend/SCEVBaseAddressExplorer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <map>

--- a/lib/DataLayoutAnalysis/FuncOrCallInst.cpp
+++ b/lib/DataLayoutAnalysis/FuncOrCallInst.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "FuncOrCallInst.h"

--- a/lib/DataLayoutAnalysis/FuncOrCallInst.h
+++ b/lib/DataLayoutAnalysis/FuncOrCallInst.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <variant>

--- a/lib/DataLayoutAnalysis/Middleend/ArrangeAccessesHierarchically.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/ArrangeAccessesHierarchically.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/DataLayoutAnalysis/Middleend/CollapseSCC.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/CollapseSCC.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <set>

--- a/lib/DataLayoutAnalysis/Middleend/CompactCompatibleArrays.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/CompactCompatibleArrays.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <compare>

--- a/lib/DataLayoutAnalysis/Middleend/DLACollapseSingleChild.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/DLACollapseSingleChild.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/PostOrderIterator.h"

--- a/lib/DataLayoutAnalysis/Middleend/DLAComputeNonInterferingComponents.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/DLAComputeNonInterferingComponents.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/DataLayoutAnalysis/Middleend/DLAComputeUpperMemberAccess.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/DLAComputeUpperMemberAccess.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <memory>

--- a/lib/DataLayoutAnalysis/Middleend/DLAPruneLayoutNodesWithoutLayout.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/DLAPruneLayoutNodesWithoutLayout.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/DataLayoutAnalysis/Middleend/DLAStep.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/DLAStep.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Support/Progress.h"

--- a/lib/DataLayoutAnalysis/Middleend/DLAStep.h
+++ b/lib/DataLayoutAnalysis/Middleend/DLAStep.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/DataLayoutAnalysis/Middleend/DecomposeStridedEdges.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/DecomposeStridedEdges.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "DLAStep.h"

--- a/lib/DataLayoutAnalysis/Middleend/DeduplicateFields.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/DeduplicateFields.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/DataLayoutAnalysis/Middleend/FieldSizeComputation.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/FieldSizeComputation.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Support/Assert.h"

--- a/lib/DataLayoutAnalysis/Middleend/FieldSizeComputation.h
+++ b/lib/DataLayoutAnalysis/Middleend/FieldSizeComputation.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdint>

--- a/lib/DataLayoutAnalysis/Middleend/MergePointeesOfPointerUnion.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/MergePointeesOfPointerUnion.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <unordered_set>

--- a/lib/DataLayoutAnalysis/Middleend/MergePointerNodes.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/MergePointerNodes.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/DepthFirstIterator.h"

--- a/lib/DataLayoutAnalysis/Middleend/PushDownPointers.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/PushDownPointers.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/DepthFirstIterator.h"

--- a/lib/DataLayoutAnalysis/Middleend/RemoveBackedges.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/RemoveBackedges.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <compare>

--- a/lib/DataLayoutAnalysis/Middleend/RemoveBackedges.h
+++ b/lib/DataLayoutAnalysis/Middleend/RemoveBackedges.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 namespace dla {

--- a/lib/DataLayoutAnalysis/Middleend/RemoveInvalidPointers.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/RemoveInvalidPointers.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "DLAStep.h"

--- a/lib/DataLayoutAnalysis/Middleend/RemoveInvalidStrideEdges.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/RemoveInvalidStrideEdges.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/PostOrderIterator.h"

--- a/lib/DataLayoutAnalysis/Middleend/ResolveLeafUnions.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/ResolveLeafUnions.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <compare>

--- a/lib/DataLayoutAnalysis/Middleend/SimplifyInstanceAtOffset0.cpp
+++ b/lib/DataLayoutAnalysis/Middleend/SimplifyInstanceAtOffset0.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <iostream>

--- a/lib/HeadersGeneration/CMakeLists.txt
+++ b/lib/HeadersGeneration/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 # ModelToHeader

--- a/lib/HeadersGeneration/DependencyGraph.cpp
+++ b/lib/HeadersGeneration/DependencyGraph.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <optional>

--- a/lib/HeadersGeneration/DependencyGraph.h
+++ b/lib/HeadersGeneration/DependencyGraph.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Support/DOTGraphTraits.h"

--- a/lib/HeadersGeneration/HelpersToHeader.cpp
+++ b/lib/HeadersGeneration/HelpersToHeader.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <functional>

--- a/lib/HeadersGeneration/HelpersToHeaderPipe.cpp
+++ b/lib/HeadersGeneration/HelpersToHeaderPipe.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Pipeline/AllRegistries.h"

--- a/lib/HeadersGeneration/ModelToHeader.cpp
+++ b/lib/HeadersGeneration/ModelToHeader.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <unordered_map>

--- a/lib/HeadersGeneration/ModelToHeaderPipe.cpp
+++ b/lib/HeadersGeneration/ModelToHeaderPipe.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Pipeline/AllRegistries.h"

--- a/lib/HeadersGeneration/ModelTypeDefinition.cpp
+++ b/lib/HeadersGeneration/ModelTypeDefinition.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng-c/Backend/DecompiledCCodeIndentation.h"

--- a/lib/HeadersGeneration/ModelTypeDefinitionPipe.cpp
+++ b/lib/HeadersGeneration/ModelTypeDefinitionPipe.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Model/Binary.h"

--- a/lib/ImportFromC/CMakeLists.txt
+++ b/lib/ImportFromC/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 # ImportFromC

--- a/lib/ImportFromC/HeaderToModel.cpp
+++ b/lib/ImportFromC/HeaderToModel.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "clang/AST/RecursiveASTVisitor.h"

--- a/lib/ImportFromC/HeaderToModel.h
+++ b/lib/ImportFromC/HeaderToModel.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/StringRef.h"

--- a/lib/ImportFromC/ImportFromCAnalysis.cpp
+++ b/lib/ImportFromC/ImportFromCAnalysis.cpp
@@ -2,7 +2,7 @@
 /// \brief Use to edit Types by omitting rewriting of Model directly
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <fstream>

--- a/lib/ImportFromC/ImportFromCAnalysis.h
+++ b/lib/ImportFromC/ImportFromCAnalysis.h
@@ -1,6 +1,6 @@
 #pragma once
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 namespace {

--- a/lib/ImportFromC/ImportFromCHelpers.h
+++ b/lib/ImportFromC/ImportFromCHelpers.h
@@ -1,6 +1,6 @@
 #pragma once
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <set>

--- a/lib/InitModelTypes/CMakeLists.txt
+++ b/lib/InitModelTypes/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(revngcInitModelTypes revngc InitModelTypes.cpp)

--- a/lib/InitModelTypes/InitModelTypes.cpp
+++ b/lib/InitModelTypes/InitModelTypes.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstddef>

--- a/lib/PromoteStackPointer/CMakeLists.txt
+++ b/lib/PromoteStackPointer/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(

--- a/lib/PromoteStackPointer/CleanupStackSizeMarkersPass.cpp
+++ b/lib/PromoteStackPointer/CleanupStackSizeMarkersPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/Instructions.h"

--- a/lib/PromoteStackPointer/ComputeStackAccessesBoundsPass.cpp
+++ b/lib/PromoteStackPointer/ComputeStackAccessesBoundsPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Analysis/LazyValueInfo.h"

--- a/lib/PromoteStackPointer/DetectStackSizePass.cpp
+++ b/lib/PromoteStackPointer/DetectStackSizePass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <optional>

--- a/lib/PromoteStackPointer/Helpers.h
+++ b/lib/PromoteStackPointer/Helpers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Support/MetaAddress.h"

--- a/lib/PromoteStackPointer/InjectStackSizeProbesAtCallSitesPass.cpp
+++ b/lib/PromoteStackPointer/InjectStackSizeProbesAtCallSitesPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/PromoteStackPointer/InstrumentStackAccessesPass.cpp
+++ b/lib/PromoteStackPointer/InstrumentStackAccessesPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/PromoteStackPointer/PromoteStackPointerPass.cpp
+++ b/lib/PromoteStackPointer/PromoteStackPointerPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <map>

--- a/lib/PromoteStackPointer/RemoveStackAlignmentPass.cpp
+++ b/lib/PromoteStackPointer/RemoveStackAlignmentPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/Constants.h"

--- a/lib/PromoteStackPointer/SegregateStackAccessesPass.cpp
+++ b/lib/PromoteStackPointer/SegregateStackAccessesPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <optional>

--- a/lib/RemoveExtractValues/CMakeLists.txt
+++ b/lib/RemoveExtractValues/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(revngcRemoveExtractValues revngc

--- a/lib/RemoveExtractValues/RemoveExtractValuesPass.cpp
+++ b/lib/RemoveExtractValues/RemoveExtractValuesPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/RemoveLiftingArtifacts/CMakeLists.txt
+++ b/lib/RemoveLiftingArtifacts/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(

--- a/lib/RemoveLiftingArtifacts/MakeSegmentRefPass.cpp
+++ b/lib/RemoveLiftingArtifacts/MakeSegmentRefPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <functional>

--- a/lib/RemoveLiftingArtifacts/MakeSegmentRefPass.h
+++ b/lib/RemoveLiftingArtifacts/MakeSegmentRefPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Pass.h"

--- a/lib/RemoveLiftingArtifacts/MakeSegmentRefPipe.cpp
+++ b/lib/RemoveLiftingArtifacts/MakeSegmentRefPipe.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/LegacyPassManager.h"

--- a/lib/RemoveLiftingArtifacts/PromoteInitCSVToUndef.cpp
+++ b/lib/RemoveLiftingArtifacts/PromoteInitCSVToUndef.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/StringRef.h"

--- a/lib/RemoveLiftingArtifacts/RemoveLiftingArtifacts.cpp
+++ b/lib/RemoveLiftingArtifacts/RemoveLiftingArtifacts.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/StringRef.h"

--- a/lib/RestructureCFG/ASTNode.cpp
+++ b/lib/RestructureCFG/ASTNode.cpp
@@ -1,7 +1,7 @@
 /// \file ASTNode.cpp
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/lib/RestructureCFG/ASTNodeUtils.cpp
+++ b/lib/RestructureCFG/ASTNodeUtils.cpp
@@ -3,7 +3,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/ADT/RecursiveCoroutine.h"

--- a/lib/RestructureCFG/ASTTree.cpp
+++ b/lib/RestructureCFG/ASTTree.cpp
@@ -1,7 +1,7 @@
 /// \file ASTTree.cpp
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/lib/RestructureCFG/BasicBlockNode.cpp
+++ b/lib/RestructureCFG/BasicBlockNode.cpp
@@ -2,7 +2,7 @@
 /// FunctionPass that applies the comb to the RegionCFG of a function
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng-c/RestructureCFG/BasicBlockNodeImpl.h"

--- a/lib/RestructureCFG/BeautifyGHAST.cpp
+++ b/lib/RestructureCFG/BeautifyGHAST.cpp
@@ -3,7 +3,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/Instructions.h"

--- a/lib/RestructureCFG/CMakeLists.txt
+++ b/lib/RestructureCFG/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(

--- a/lib/RestructureCFG/ExprNode.cpp
+++ b/lib/RestructureCFG/ExprNode.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Support/Debug.h"

--- a/lib/RestructureCFG/FallThroughScopeAnalysis.cpp
+++ b/lib/RestructureCFG/FallThroughScopeAnalysis.cpp
@@ -3,7 +3,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/RestructureCFG/FallThroughScopeAnalysis.h
+++ b/lib/RestructureCFG/FallThroughScopeAnalysis.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng/Model/IRHelpers.h"

--- a/lib/RestructureCFG/InlineDispatcherSwitch.cpp
+++ b/lib/RestructureCFG/InlineDispatcherSwitch.cpp
@@ -4,7 +4,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <algorithm>

--- a/lib/RestructureCFG/InlineDispatcherSwitch.h
+++ b/lib/RestructureCFG/InlineDispatcherSwitch.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "FallThroughScopeAnalysis.h"

--- a/lib/RestructureCFG/MetaRegion.cpp
+++ b/lib/RestructureCFG/MetaRegion.cpp
@@ -2,7 +2,7 @@
 /// FunctionPass that applies the comb to the RegionCFG of a function
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng-c/RestructureCFG/MetaRegionImpl.h"

--- a/lib/RestructureCFG/PromoteCallNoReturn.cpp
+++ b/lib/RestructureCFG/PromoteCallNoReturn.cpp
@@ -3,7 +3,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/RestructureCFG/PromoteCallNoReturn.h
+++ b/lib/RestructureCFG/PromoteCallNoReturn.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 // Forward declarations

--- a/lib/RestructureCFG/RegionCFGTree.cpp
+++ b/lib/RestructureCFG/RegionCFGTree.cpp
@@ -2,7 +2,7 @@
 /// FunctionPass that applies the comb to the RegionCFG of a function
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng-c/RestructureCFG/RegionCFGTreeImpl.h"

--- a/lib/RestructureCFG/RestructureCFG.cpp
+++ b/lib/RestructureCFG/RestructureCFG.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <iterator>

--- a/lib/RestructureCFG/SimplifyCompareNode.cpp
+++ b/lib/RestructureCFG/SimplifyCompareNode.cpp
@@ -3,7 +3,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/RestructureCFG/SimplifyCompareNode.h
+++ b/lib/RestructureCFG/SimplifyCompareNode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 // Forward declarations

--- a/lib/RestructureCFG/SimplifyDualSwitch.cpp
+++ b/lib/RestructureCFG/SimplifyDualSwitch.cpp
@@ -3,7 +3,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/RestructureCFG/SimplifyDualSwitch.h
+++ b/lib/RestructureCFG/SimplifyDualSwitch.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 // Forward declarations

--- a/lib/RestructureCFG/SimplifyHybridNot.cpp
+++ b/lib/RestructureCFG/SimplifyHybridNot.cpp
@@ -3,7 +3,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/RestructureCFG/SimplifyHybridNot.h
+++ b/lib/RestructureCFG/SimplifyHybridNot.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 // Forward declarations

--- a/lib/RestructureCFG/SimplifyImplicitStatement.cpp
+++ b/lib/RestructureCFG/SimplifyImplicitStatement.cpp
@@ -4,7 +4,7 @@
 ///
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/IRBuilder.h"

--- a/lib/RestructureCFG/SimplifyImplicitStatement.h
+++ b/lib/RestructureCFG/SimplifyImplicitStatement.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 // Forward declarations

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(revngcSupport revngc FunctionTags.cpp IRHelpers.cpp

--- a/lib/Support/FunctionTags.cpp
+++ b/lib/Support/FunctionTags.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/IR/DerivedTypes.h"

--- a/lib/Support/IRHelpers.cpp
+++ b/lib/Support/IRHelpers.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <type_traits>

--- a/lib/Support/ModelHelpers.cpp
+++ b/lib/Support/ModelHelpers.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <utility>

--- a/lib/Support/SimplifyCFGWithHoistAndSinkPass.cpp
+++ b/lib/Support/SimplifyCFGWithHoistAndSinkPass.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Passes/PassBuilder.h"

--- a/lib/TypeNames/CMakeLists.txt
+++ b/lib/TypeNames/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_analyses_library(revngcTypeNames revngc LLVMTypeNames.cpp

--- a/lib/TypeNames/LLVMTypeNames.cpp
+++ b/lib/TypeNames/LLVMTypeNames.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/SmallString.h"

--- a/lib/TypeNames/ModelToPTMLTypeHelpers.cpp
+++ b/lib/TypeNames/ModelToPTMLTypeHelpers.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <unordered_map>

--- a/lib/TypeNames/ModelTypeNames.cpp
+++ b/lib/TypeNames/ModelTypeNames.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/ADT/STLExtras.h"

--- a/lib/mlir/Dialect/Clift/IR/CMakeLists.txt
+++ b/lib/mlir/Dialect/Clift/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 add_mlir_dialect_library(

--- a/lib/mlir/Dialect/Clift/IR/Clift.cpp
+++ b/lib/mlir/Dialect/Clift/IR/Clift.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "mlir/IR/DialectImplementation.h"

--- a/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <set>

--- a/lib/mlir/Dialect/Clift/IR/CliftEnums.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftEnums.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h"

--- a/lib/mlir/Dialect/Clift/IR/CliftInterfaces.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftInterfaces.cpp
@@ -2,7 +2,7 @@
 /// Tests for the Clift Dialect
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 //
 #include "revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.h"

--- a/lib/mlir/Dialect/Clift/IR/CliftOps.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftOps.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "mlir/IR/RegionGraphTraits.h"

--- a/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <string>

--- a/lib/mlir/Pipes/MLIRPipe.cpp
+++ b/lib/mlir/Pipes/MLIRPipe.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 #include <string>
 

--- a/libexec/revng/revng-check-decompiled-c
+++ b/libexec/revng/revng-check-decompiled-c
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 set -euo pipefail

--- a/share/revng-c/compile-flags.cfg
+++ b/share/revng-c/compile-flags.cfg
@@ -1,5 +1,5 @@
 ####
-#### This file is distributed under the MIT License. See LICENSE.md for details.
+#### This file is distributed under the MIT License. See LICENSE.mit for details.
 ####
 
 -std=c11

--- a/share/revng-c/include/revng-attributes.h
+++ b/share/revng-c/include/revng-attributes.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #define STR(x) #x

--- a/share/revng-c/include/revng-primitive-types.h
+++ b/share/revng-c/include/revng-primitive-types.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "limits.h"

--- a/share/revng/cmake/revngcConfig.cmake
+++ b/share/revng/cmake/revngcConfig.cmake
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 get_filename_component(revngc_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)

--- a/share/revng/pipelines/revng-c-pipelines.yml
+++ b/share/revng/pipelines/revng-c-pipelines.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Component: revng-c

--- a/share/revng/test/configuration/revng-c/daemon.yml
+++ b/share/revng/test/configuration/revng-c/daemon.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 commands:

--- a/share/revng/test/configuration/revng-c/decompilation.yml
+++ b/share/revng/test/configuration/revng-c/decompilation.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 commands:

--- a/share/revng/test/configuration/revng-c/detect-stack-size.yml
+++ b/share/revng/test/configuration/revng-c/detect-stack-size.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 commands:

--- a/share/revng/test/configuration/revng-c/docs.yml
+++ b/share/revng/test/configuration/revng-c/docs.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 commands:

--- a/share/revng/test/configuration/revng-c/end-to-end.yml
+++ b/share/revng/test/configuration/revng-c/end-to-end.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 commands:

--- a/share/revng/test/configuration/revng-c/import-from-c.yml
+++ b/share/revng/test/configuration/revng-c/import-from-c.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 tags:

--- a/share/revng/test/configuration/revng-c/model-to-header.yml
+++ b/share/revng/test/configuration/revng-c/model-to-header.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 tags:

--- a/share/revng/test/configuration/revng-c/runtime-segregation-tests.yml
+++ b/share/revng/test/configuration/revng-c/runtime-segregation-tests.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 commands:

--- a/share/revng/test/configuration/revng-c/segregate-stack-accesses.yml
+++ b/share/revng/test/configuration/revng-c/segregate-stack-accesses.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 commands:

--- a/share/revng/test/tests/analysis/Decompilation/clang/linked-lists.c.filecheck
+++ b/share/revng/test/tests/analysis/Decompilation/clang/linked-lists.c.filecheck
@@ -1,4 +1,4 @@
-This file is distributed under the MIT License. See LICENSE.md for details.
+This file is distributed under the MIT License. See LICENSE.mit for details.
 
 
 The init_list function should have the proper detected return type, a pointer to

--- a/share/revng/test/tests/analysis/Decompilation/clang/linked-lists.c.model.yml
+++ b/share/revng/test/tests/analysis/Decompilation/clang/linked-lists.c.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 Functions:
   - OriginalName: init_list

--- a/share/revng/test/tests/analysis/Decompilation/x86-64/dual-case-switch.c.filecheck
+++ b/share/revng/test/tests/analysis/Decompilation/x86-64/dual-case-switch.c.filecheck
@@ -1,4 +1,4 @@
-This file is distributed under the MIT License. See LICENSE.md for details.
+This file is distributed under the MIT License. See LICENSE.mit for details.
 
 We should have correctly promoted the exit dispatcher switch to an if (switch
 with two cases). The condition of the if should be the `loop_state_var` (we are

--- a/share/revng/test/tests/analysis/Decompilation/x86-64/dual-case-switch.c.model.yml
+++ b/share/revng/test/tests/analysis/Decompilation/x86-64/dual-case-switch.c.model.yml
@@ -1,5 +1,5 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 Architecture: x86_64

--- a/share/revng/test/tests/analysis/Decompilation/x86-64/pretty-ints.c.filecheck
+++ b/share/revng/test/tests/analysis/Decompilation/x86-64/pretty-ints.c.filecheck
@@ -1,4 +1,4 @@
-This file is distributed under the MIT License. See LICENSE.md for details.
+This file is distributed under the MIT License. See LICENSE.mit for details.
 
 The following things should be printed in hexadecimal
 

--- a/share/revng/test/tests/analysis/Decompilation/x86-64/pretty-ints.c.model.yml
+++ b/share/revng/test/tests/analysis/Decompilation/x86-64/pretty-ints.c.model.yml
@@ -1,5 +1,5 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 Architecture: x86_64

--- a/share/revng/test/tests/analysis/Decompilation/x86-64/segments-and-sections.c.filecheck
+++ b/share/revng/test/tests/analysis/Decompilation/x86-64/segments-and-sections.c.filecheck
@@ -1,4 +1,4 @@
-This file is distributed under the MIT License. See LICENSE.md for details.
+This file is distributed under the MIT License. See LICENSE.mit for details.
 
 The print_string function should use an inline string literal.
 

--- a/share/revng/test/tests/analysis/Decompilation/x86-64/segments-and-sections.c.model.yml
+++ b/share/revng/test/tests/analysis/Decompilation/x86-64/segments-and-sections.c.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 Segments:
   - IsReadable: true

--- a/share/revng/test/tests/analysis/DetectStackSize/dynamic_native/stackframe.c.model.yml
+++ b/share/revng/test/tests/analysis/DetectStackSize/dynamic_native/stackframe.c.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype-with-complex-args.model.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype-with-complex-args.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype-with-complex-args.model.yml.ccode
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype-with-complex-args.model.yml.ccode
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 typedef _ABI(SystemV_x86_64) _struct_3005 function_type_cabifunction_1(_struct_3005, _struct_3006[], _struct_3006**, _typedef_3011*);

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype-with-complex-args.model.yml.location
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype-with-complex-args.model.yml.location
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 /type/3000-CABIFunctionType

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype-with-complex-args.model.yml.reference.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype-with-complex-args.model.yml.reference.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype.model.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype.model.yml.ccode
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype.model.yml.ccode
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 typedef _ABI(SystemV_x86_64) int64_t function_type_cabifunction_1 (int32_t, int8_t **);

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype.model.yml.location
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype.model.yml.location
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 /type/3000-CABIFunctionType

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype.model.yml.reference.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/cabifunctiontype.model.yml.reference.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/enumtype.model.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/enumtype.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/enumtype.model.yml.ccode
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/enumtype.model.yml.ccode
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 enum _ENUM_UNDERLYING(uint32_t) _PACKED my_enum {

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/enumtype.model.yml.location
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/enumtype.model.yml.location
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 /type/3000-EnumType

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/enumtype.model.yml.reference.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/enumtype.model.yml.reference.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/primitive-types.model.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/primitive-types.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/primitive-types.model.yml.ccode
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/primitive-types.model.yml.ccode
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 union _PACKED my_union {

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/primitive-types.model.yml.location
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/primitive-types.model.yml.location
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 /type/3000-UnionType

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/primitive-types.model.yml.reference.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/primitive-types.model.yml.reference.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-multiple-regs-for-return-val.model.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-multiple-regs-for-return-val.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-multiple-regs-for-return-val.model.yml.ccode
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-multiple-regs-for-return-val.model.yml.ccode
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 _ABI(raw)

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-multiple-regs-for-return-val.model.yml.location
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-multiple-regs-for-return-val.model.yml.location
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 /function/0x400000:Code_x86_64

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-multiple-regs-for-return-val.model.yml.reference.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-multiple-regs-for-return-val.model.yml.reference.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Functions:

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-single-reg-for-return-val.model.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-single-reg-for-return-val.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-single-reg-for-return-val.model.yml.ccode
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-single-reg-for-return-val.model.yml.ccode
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 _ABI(raw) int64_t _REG(rax) new_function_name(int64_t _REG(rcx) fd33);

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-single-reg-for-return-val.model.yml.location
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-single-reg-for-return-val.model.yml.location
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 /function/0x400000:Code_x86_64

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-single-reg-for-return-val.model.yml.reference.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/rft-single-reg-for-return-val.model.yml.reference.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Functions:

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/struct.model.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/struct.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/struct.model.yml.ccode
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/struct.model.yml.ccode
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 struct _PACKED my_struct {

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/struct.model.yml.location
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/struct.model.yml.location
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 /type/3001-StructType

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/struct.model.yml.reference.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/struct.model.yml.reference.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/typedef.model.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/typedef.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/typedef.model.yml.ccode
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/typedef.model.yml.ccode
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 typedef int16_t my_typedef;

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/typedef.model.yml.location
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/typedef.model.yml.location
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 /type/3000-TypedefType

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/typedef.model.yml.reference.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/typedef.model.yml.reference.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/union.model.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/union.model.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/union.model.yml.ccode
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/union.model.yml.ccode
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 union _PACKED new_union_name {

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/union.model.yml.location
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/union.model.yml.location
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 /type/3000-UnionType

--- a/share/revng/test/tests/analysis/ImportFromCAnalysis/union.model.yml.reference.yml
+++ b/share/revng/test/tests/analysis/ImportFromCAnalysis/union.model.yml.reference.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/analysis/SegregateStackAccesses/dynamic_native/segregate.c.filecheck.ll
+++ b/share/revng/test/tests/analysis/SegregateStackAccesses/dynamic_native/segregate.c.filecheck.ll
@@ -1,5 +1,5 @@
 ;
-; This file is distributed under the MIT License. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.mit for details.
 ;
 
 CHECK: define i64 @local_raw_primitives_on_registers(i64 %[[ARG1:.*]], i64 %[[ARG2:.*]]) [[IGN:.*]] {

--- a/share/revng/test/tests/analysis/SegregateStackAccesses/dynamic_native/segregate.c.override.yml
+++ b/share/revng/test/tests/analysis/SegregateStackAccesses/dynamic_native/segregate.c.override.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 ---
 Functions:

--- a/share/revng/test/tests/model-to-header/annotate-attibutes.model.yml
+++ b/share/revng/test/tests/model-to-header/annotate-attibutes.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Functions:

--- a/share/revng/test/tests/model-to-header/annotate-attibutes.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/annotate-attibutes.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 # CHECK: typedef _ABI(SystemV_x86_64) void _cabifunction_3001(int32_t, generic64_t, uint16_t);

--- a/share/revng/test/tests/model-to-header/do-not-generate-struct-for-stack-type.h.model.yml
+++ b/share/revng/test/tests/model-to-header/do-not-generate-struct-for-stack-type.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Functions:

--- a/share/revng/test/tests/model-to-header/do-not-generate-struct-for-stack-type.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/do-not-generate-struct-for-stack-type.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 # Stack types will be generated inline in the decompiled functions.

--- a/share/revng/test/tests/model-to-header/do-not-inline-types-pointing-to-itself.h.model.yml
+++ b/share/revng/test/tests/model-to-header/do-not-inline-types-pointing-to-itself.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/model-to-header/do-not-inline-types-pointing-to-itself.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/do-not-inline-types-pointing-to-itself.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: typedef struct _PACKED B B;

--- a/share/revng/test/tests/model-to-header/do-not-inline-used-stack-type.h.model.yml
+++ b/share/revng/test/tests/model-to-header/do-not-inline-used-stack-type.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Functions:

--- a/share/revng/test/tests/model-to-header/do-not-inline-used-stack-type.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/do-not-inline-used-stack-type.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: typedef struct _PACKED _struct_3001 _struct_3001;

--- a/share/revng/test/tests/model-to-header/inline-complex-struct.h.model.yml
+++ b/share/revng/test/tests/model-to-header/inline-complex-struct.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/model-to-header/inline-complex-struct.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/inline-complex-struct.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: typedef enum _PACKED E2 E2;

--- a/share/revng/test/tests/model-to-header/inline-enum.h.model.yml
+++ b/share/revng/test/tests/model-to-header/inline-enum.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/model-to-header/inline-enum.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/inline-enum.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: typedef struct _PACKED B B;

--- a/share/revng/test/tests/model-to-header/inline-struct.h.model.yml
+++ b/share/revng/test/tests/model-to-header/inline-struct.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/model-to-header/inline-struct.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/inline-struct.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: typedef struct _PACKED B B;

--- a/share/revng/test/tests/model-to-header/inline-union.h.model.yml
+++ b/share/revng/test/tests/model-to-header/inline-union.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/model-to-header/inline-union.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/inline-union.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: typedef struct _PACKED B B;

--- a/share/revng/test/tests/model-to-header/pointer-to-struct.h.model.yml
+++ b/share/revng/test/tests/model-to-header/pointer-to-struct.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Functions:

--- a/share/revng/test/tests/model-to-header/pointer-to-struct.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/pointer-to-struct.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: typedef struct _PACKED B B;

--- a/share/revng/test/tests/model-to-header/primitive-types.h.model.yml
+++ b/share/revng/test/tests/model-to-header/primitive-types.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Functions:

--- a/share/revng/test/tests/model-to-header/primitive-types.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/primitive-types.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: void fn(int32_t *b, generic64_t *c, uint16_t *d);

--- a/share/revng/test/tests/model-to-header/struct.h.model.yml
+++ b/share/revng/test/tests/model-to-header/struct.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/model-to-header/struct.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/struct.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: typedef struct _PACKED B B;

--- a/share/revng/test/tests/model-to-header/union.h.model.yml
+++ b/share/revng/test/tests/model-to-header/union.h.model.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 Types:

--- a/share/revng/test/tests/model-to-header/union.h.model.yml.filecheck
+++ b/share/revng/test/tests/model-to-header/union.h.model.yml.filecheck
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 CHECK: typedef struct _PACKED B B;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 add_subdirectory(unit)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 cmake_policy(SET CMP0060 NEW)

--- a/tests/unit/Clift.cpp
+++ b/tests/unit/Clift.cpp
@@ -2,7 +2,7 @@
 /// Tests for the Clift Dialect
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/tests/unit/CombingPass.cpp
+++ b/tests/unit/CombingPass.cpp
@@ -2,7 +2,7 @@
 /// Tests for CombingPass
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include <cstdlib>

--- a/tests/unit/DLAStepManager.cpp
+++ b/tests/unit/DLAStepManager.cpp
@@ -2,7 +2,7 @@
 /// Tests for dla::StepManager
 
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #define BOOST_TEST_MODULE DLAStepManager

--- a/tests/unit/DLASteps.cpp
+++ b/tests/unit/DLASteps.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #define BOOST_TEST_MODULE DLASteps

--- a/tests/unit/llvm_lit_tests/CheckAddPrimitiveTypes.ll.yml
+++ b/tests/unit/llvm_lit_tests/CheckAddPrimitiveTypes.ll.yml
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 ---

--- a/tests/unit/llvm_lit_tests/Example.ll
+++ b/tests/unit/llvm_lit_tests/Example.ll
@@ -1,5 +1,5 @@
 ;
-; This file is distributed under the MIT License. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.mit for details.
 ;
 
 ; RUN: %revngopt %s -S -o - | FileCheck %s

--- a/tests/unit/llvm_lit_tests/OperatorPrecedenceResolutionPass.ll
+++ b/tests/unit/llvm_lit_tests/OperatorPrecedenceResolutionPass.ll
@@ -1,5 +1,5 @@
 ;
-; This file is distributed under the MIT License. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.mit for details.
 ;
 
 ; RUN: %revngopt %s -operatorprecedence-resolution -language=c -S -o - | FileCheck %s --check-prefix=C-LANG

--- a/tests/unit/llvm_lit_tests/RemoveExtractValues.ll
+++ b/tests/unit/llvm_lit_tests/RemoveExtractValues.ll
@@ -1,5 +1,5 @@
 ;
-; This file is distributed under the MIT License. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.mit for details.
 ;
 
 ; RUN: %revngopt %s -remove-extractvalues | %revngopt -enable-new-pm=1 -O2 -S | FileCheck %s

--- a/tests/unit/llvm_lit_tests/TernaryReduction.ll
+++ b/tests/unit/llvm_lit_tests/TernaryReduction.ll
@@ -1,5 +1,5 @@
 ;
-; This file is distributed under the MIT License. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.mit for details.
 ;
 
 ; RUN: %revngopt %s -ternary-reduction -S -o - | FileCheck %s

--- a/tests/unit/llvm_lit_tests/TwosComplementArithmeticNormalization.ll
+++ b/tests/unit/llvm_lit_tests/TwosComplementArithmeticNormalization.ll
@@ -1,5 +1,5 @@
 ;
-; This file is distributed under the MIT License. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.mit for details.
 ;
 
 ; RUN: %revngopt %s -twoscomplement-normalization -S -o - | FileCheck %s

--- a/tests/unit/llvm_lit_tests/lit.cfg.py
+++ b/tests/unit/llvm_lit_tests/lit.cfg.py
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 # lit defines config and then loads this file, so we must prevent check-conventions to complain about config not being defined
 # flake8: noqa: F821

--- a/tests/unit/llvm_lit_tests/lit.site.cfg.py.in
+++ b/tests/unit/llvm_lit_tests/lit.site.cfg.py.in
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 import os

--- a/tests/unit/llvm_lit_tests/peephole-optimization-for-decompilation.ll
+++ b/tests/unit/llvm_lit_tests/peephole-optimization-for-decompilation.ll
@@ -1,5 +1,5 @@
 ;
-; This file is distributed under the MIT License. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.mit for details.
 ;
 
 ; RUN: %revngopt -peephole-opt-for-decompilation %s -S -o - | FileCheck %s

--- a/tests/unit/mlir_lit_tests/ParseCliftTypes.mlir
+++ b/tests/unit/mlir_lit_tests/ParseCliftTypes.mlir
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 // RUN: diff <(revng clift-opt %s -o -) <(revng clift-opt %s -o - | revng clift-opt -o -)
 !const_int32_t = !clift.primitive<is_const = true, SignedKind 4>

--- a/tests/unit/mlir_lit_tests/ParseRecursiveStructs.mlir
+++ b/tests/unit/mlir_lit_tests/ParseRecursiveStructs.mlir
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 // RUN: diff <(revng clift-opt %s -o -) <(revng clift-opt %s -o - | revng clift-opt -o -)
 #dc1 = #clift.union<id = 4, name = "dc", fields = [<offset = 10, name = "dc1", type = !clift.primitive<is_const = true, SignedKind 4>>, <offset = 20, name = "dc2", type = !clift.pointer<pointee_type = !clift.defined<is_const = true, #clift.union<id = 4>>, pointer_size = 8>>]>

--- a/tests/unit/mlir_lit_tests/__init__.py
+++ b/tests/unit/mlir_lit_tests/__init__.py
@@ -1,3 +1,3 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #

--- a/tests/unit/mlir_lit_tests/lit.cfg.py
+++ b/tests/unit/mlir_lit_tests/lit.cfg.py
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 # lit defines config and then loads this file, so we must prevent check-conventions to complain about config not being defined
 # flake8: noqa: F821

--- a/tests/unit/mlir_lit_tests/lit.site.cfg.py.in
+++ b/tests/unit/mlir_lit_tests/lit.site.cfg.py.in
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 import os

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 add_subdirectory(clift-opt)

--- a/tools/clift-opt/CMakeLists.txt
+++ b/tools/clift-opt/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# This file is distributed under the MIT License. See LICENSE.md for details.
+# This file is distributed under the MIT License. See LICENSE.mit for details.
 #
 
 revng_add_executable(revng-clift-opt Main.cpp)

--- a/tools/clift-opt/Main.cpp
+++ b/tools/clift-opt/Main.cpp
@@ -1,5 +1,5 @@
 //
-// This file is distributed under the MIT License. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.mit for details.
 //
 
 #include "llvm/Support/CommandLine.h"


### PR DESCRIPTION
The license header on some files refers to a non-existent `LICENSE.md`. Based on context I assume the license that should be linked is the one held at `LICENSE.mit`.