### PR TITLE
Clift cleanup

### DIFF
--- a/include/revng-c/mlir/Dialect/Clift/IR/Clift.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/Clift.td
@@ -20,7 +20,7 @@ def Clift_Dialect : Dialect {
   let name = "clift";
 
   // The C++ namespace that the dialect, and its sub-components, get placed in
-  let cppNamespace = "::mlir::clift";
+  let cppNamespace = "mlir::clift";
   let useDefaultTypePrinterParser = 0;
   let useDefaultAttributePrinterParser = 0;
   let useFoldAPI = kEmitFoldAdaptorFolder;

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
@@ -74,7 +74,7 @@ public:
 
   bool isDefinition() const;
   uint64_t getByteSize() const;
-  std::string getAlias() const;
+  bool getAlias(llvm::raw_ostream &OS) const;
 
   static Attribute parse(AsmParser &Parser);
   void print(AsmPrinter &Printer) const;
@@ -134,7 +134,7 @@ public:
 
   bool isDefinition() const;
   uint64_t getByteSize() const;
-  std::string getAlias() const;
+  bool getAlias(llvm::raw_ostream &OS) const;
 
   static Attribute parse(AsmParser &Parser);
   void print(AsmPrinter &Printer) const;

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
@@ -79,18 +79,18 @@ public:
   static Attribute parse(AsmParser &Parser);
   void print(AsmPrinter &Printer) const;
 
-  static LogicalResult verify(function_ref<InFlightDiagnostic()> emitError,
+  static LogicalResult verify(function_ref<InFlightDiagnostic()> EmitError,
                               uint64_t ID);
-  static LogicalResult verify(function_ref<InFlightDiagnostic()> emitError,
+  static LogicalResult verify(function_ref<InFlightDiagnostic()> EmitError,
                               uint64_t ID,
                               llvm::StringRef Name,
                               uint64_t Size,
                               llvm::ArrayRef<FieldAttr> Fields);
 
-  void walkImmediateSubElements(function_ref<void(Attribute)> walkAttrsFn,
-                                function_ref<void(Type)> walkTypesFn) const;
-  Attribute replaceImmediateSubElements(ArrayRef<Attribute> replAttrs,
-                                        ArrayRef<Type> replTypes) const;
+  void walkImmediateSubElements(function_ref<void(Attribute)> WalkAttrs,
+                                function_ref<void(Type)> WalkTypes) const;
+  Attribute replaceImmediateSubElements(ArrayRef<Attribute> NewAttrs,
+                                        ArrayRef<Type> NewTypes) const;
 };
 
 struct UnionTypeAttrStorage;
@@ -139,9 +139,9 @@ public:
   static Attribute parse(AsmParser &Parser);
   void print(AsmPrinter &Printer) const;
 
-  static LogicalResult verify(function_ref<InFlightDiagnostic()> emitError,
+  static LogicalResult verify(function_ref<InFlightDiagnostic()> EmitError,
                               uint64_t ID);
-  static LogicalResult verify(function_ref<InFlightDiagnostic()> emitError,
+  static LogicalResult verify(function_ref<InFlightDiagnostic()> EmitError,
                               uint64_t ID,
                               llvm::StringRef Name,
                               llvm::ArrayRef<FieldAttr> Fields);
@@ -151,9 +151,9 @@ public:
   // to do. Notice that since LLVM17 these are no longer methods requested
   // by the SubElementAttrInterface but are instead a builtin property of
   // all types and attributes, so it will break.
-  void walkImmediateSubElements(function_ref<void(Attribute)> walkAttrsFn,
-                                function_ref<void(Type)> walkTypesFn) const;
-  Attribute replaceImmediateSubElements(ArrayRef<Attribute> replAttrs,
-                                        ArrayRef<Type> replTypes) const;
+  void walkImmediateSubElements(function_ref<void(Attribute)> WalkAttrs,
+                                function_ref<void(Type)> WalkTypes) const;
+  Attribute replaceImmediateSubElements(ArrayRef<Attribute> NewAttrs,
+                                        ArrayRef<Type> NewTypes) const;
 };
 } // namespace mlir::clift

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
@@ -36,7 +36,7 @@ class StructTypeAttr
                                      StructTypeAttrStorage,
                                      SubElementAttrInterface::Trait,
                                      SizedType::Trait,
-                                     TypeDefinition::Trait,
+                                     TypeDefinitionAttr::Trait,
                                      AliasableAttr::Trait,
                                      AttributeTrait::IsMutable> {
 public:
@@ -99,7 +99,7 @@ class UnionTypeAttr : public Attribute::AttrBase<UnionTypeAttr,
                                                  UnionTypeAttrStorage,
                                                  SubElementAttrInterface::Trait,
                                                  SizedType::Trait,
-                                                 TypeDefinition::Trait,
+                                                 TypeDefinitionAttr::Trait,
                                                  AliasableAttr::Trait,
                                                  AttributeTrait::IsMutable> {
 public:

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h
@@ -29,33 +29,33 @@ namespace mlir::clift {
 // discourse.llvm.org/t/custom-walk-and-replace-for-non-tablegen-types/74229
 // This is very brittle and it is very likely that it will change again in
 // future llvm releases
-struct StructTypeStorage;
-class StructType
-  : public ::mlir::Attribute::AttrBase<StructType,
-                                       Attribute,
-                                       StructTypeStorage,
-                                       SubElementAttrInterface::Trait,
-                                       SizedType::Trait,
-                                       TypeDefinition::Trait,
-                                       AliasableAttr::Trait,
-                                       AttributeTrait::IsMutable> {
+struct StructTypeAttrStorage;
+class StructTypeAttr
+  : public mlir::Attribute::AttrBase<StructTypeAttr,
+                                     Attribute,
+                                     StructTypeAttrStorage,
+                                     SubElementAttrInterface::Trait,
+                                     SizedType::Trait,
+                                     TypeDefinition::Trait,
+                                     AliasableAttr::Trait,
+                                     AttributeTrait::IsMutable> {
 public:
   using Base::Base;
 
-  static StructType get(MLIRContext *Context, uint64_t ID);
+  static StructTypeAttr get(MLIRContext *Context, uint64_t ID);
 
-  static StructType
+  static StructTypeAttr
   getChecked(llvm::function_ref<InFlightDiagnostic()> EmitError,
              MLIRContext *Context,
              uint64_t ID);
 
-  static StructType get(MLIRContext *Context,
-                        uint64_t ID,
-                        llvm::StringRef Name,
-                        uint64_t Size,
-                        llvm::ArrayRef<FieldAttr> Fields);
+  static StructTypeAttr get(MLIRContext *Context,
+                            uint64_t ID,
+                            llvm::StringRef Name,
+                            uint64_t Size,
+                            llvm::ArrayRef<FieldAttr> Fields);
 
-  static StructType
+  static StructTypeAttr
   getChecked(llvm::function_ref<InFlightDiagnostic()> EmitError,
              MLIRContext *Context,
              uint64_t ID,
@@ -93,31 +93,31 @@ public:
                                         ArrayRef<Type> replTypes) const;
 };
 
-struct UnionTypeStorage;
-class UnionType : public Attribute::AttrBase<UnionType,
-                                             Attribute,
-                                             UnionTypeStorage,
-                                             SubElementAttrInterface::Trait,
-                                             SizedType::Trait,
-                                             TypeDefinition::Trait,
-                                             AliasableAttr::Trait,
-                                             AttributeTrait::IsMutable> {
+struct UnionTypeAttrStorage;
+class UnionTypeAttr : public Attribute::AttrBase<UnionTypeAttr,
+                                                 Attribute,
+                                                 UnionTypeAttrStorage,
+                                                 SubElementAttrInterface::Trait,
+                                                 SizedType::Trait,
+                                                 TypeDefinition::Trait,
+                                                 AliasableAttr::Trait,
+                                                 AttributeTrait::IsMutable> {
 public:
   using Base::Base;
 
-  static UnionType get(MLIRContext *Context, uint64_t ID);
+  static UnionTypeAttr get(MLIRContext *Context, uint64_t ID);
 
-  static UnionType
+  static UnionTypeAttr
   getChecked(llvm::function_ref<InFlightDiagnostic()> EmitError,
              MLIRContext *Context,
              uint64_t ID);
 
-  static UnionType get(MLIRContext *Context,
-                       uint64_t ID,
-                       llvm::StringRef Name,
-                       llvm::ArrayRef<FieldAttr> Fields);
+  static UnionTypeAttr get(MLIRContext *Context,
+                           uint64_t ID,
+                           llvm::StringRef Name,
+                           llvm::ArrayRef<FieldAttr> Fields);
 
-  static UnionType
+  static UnionTypeAttr
   getChecked(llvm::function_ref<InFlightDiagnostic()> EmitError,
              MLIRContext *Context,
              uint64_t ID,

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.td
@@ -73,14 +73,14 @@ def EnumFieldAttr : Clift_Attr<"EnumField", "enum_field", [DeclareAttrInterfaceM
   let assemblyFormat = "`<`struct($name, $raw_value)`>`";
 }
 
-def Clift_EnumAttr : Clift_Attr<"Enum", "enum", [DeclareAttrInterfaceMethods<AliasableAttr>, DeclareAttrInterfaceMethods<SizedType, ["getByteSize"]>, TypeDefinition, SubElementAttrInterface]> {
+def Clift_EnumTypeAttr : Clift_Attr<"EnumType", "enum", [DeclareAttrInterfaceMethods<AliasableAttr>, DeclareAttrInterfaceMethods<SizedType, ["getByteSize"]>, TypeDefinitionAttr, SubElementAttrInterface]> {
   let summary = "Clift enum type";
 
   let parameters = (ins "uint64_t":$id, StringRefParameter<>:$name, "mlir::Type":$underlying_type, ArrayRefParameter<"mlir::clift::EnumFieldAttr">:$fields);
 
   let builders = [
     TypeBuilderWithInferredContext<(ins "uint64_t":$ID, "llvm::StringRef":$Name, "mlir::Type":$ElementType, "llvm::ArrayRef<mlir::clift::EnumFieldAttr>":$Fields), [{
-      return EnumAttr::get(ElementType.getContext(), ID, Name, ElementType, Fields);
+      return EnumTypeAttr::get(ElementType.getContext(), ID, Name, ElementType, Fields);
      }]>,
   ];
 
@@ -92,14 +92,14 @@ def Clift_EnumAttr : Clift_Attr<"Enum", "enum", [DeclareAttrInterfaceMethods<Ali
   let assemblyFormat = "`<`struct($id, $name, $underlying_type)  `,` `fields` `=` `[` $fields `]``>` ";
 }
 
-def Clift_TypedefAttr: Clift_Attr<"Typedef", "typedef", [DeclareAttrInterfaceMethods<AliasableAttr>, DeclareAttrInterfaceMethods<SizedType, ["getByteSize"]>, TypeDefinition, SubElementAttrInterface]> {
+def Clift_TypedefTypeAttr: Clift_Attr<"TypedefType", "typedef", [DeclareAttrInterfaceMethods<AliasableAttr>, DeclareAttrInterfaceMethods<SizedType, ["getByteSize"]>, TypeDefinitionAttr, SubElementAttrInterface]> {
   let summary = "Clift typedef type";
 
   let parameters = (ins "uint64_t":$id, StringRefParameter<>:$name, "mlir::clift::ValueType":$underlying_type);
 
   let builders = [
     TypeBuilderWithInferredContext<(ins "uint64_t":$ID, "llvm::StringRef":$Name, "mlir::clift::ValueType":$ElementType), [{
-      return TypedefAttr::get(ElementType.getContext(), ID, Name, ElementType);
+      return TypedefTypeAttr::get(ElementType.getContext(), ID, Name, ElementType);
      }]>,
   ];
 
@@ -111,14 +111,14 @@ def Clift_TypedefAttr: Clift_Attr<"Typedef", "typedef", [DeclareAttrInterfaceMet
   let assemblyFormat = "`<`struct($id, $name, $underlying_type) `>` ";
 }
 
-def Clift_FunctionAttr : Clift_Attr<"Function", "function", [DeclareAttrInterfaceMethods<AliasableAttr>, DeclareAttrInterfaceMethods<SizedType, ["getByteSize"]>, TypeDefinition, SubElementAttrInterface]> {
+def Clift_FunctionTypeAttr : Clift_Attr<"FunctionType", "function", [DeclareAttrInterfaceMethods<AliasableAttr>, DeclareAttrInterfaceMethods<SizedType, ["getByteSize"]>, TypeDefinitionAttr, SubElementAttrInterface]> {
   let summary = "Clift function type";
 
   let parameters = (ins "uint64_t":$id, StringRefParameter<>:$name, "mlir::clift::ValueType":$return_type, OptionalArrayRefParameter<"mlir::clift::FunctionArgumentAttr">:$argument_types);
 
   let builders = [
     TypeBuilderWithInferredContext<(ins "uint64_t":$ID, "mlir::clift::ValueType":$ReturnType,   CArg<"llvm::ArrayRef<mlir::clift::FunctionArgumentAttr>", "{}">:$InputTypes, CArg<"llvm::StringRef", "\"\"">:$Name), [{
-      return FunctionAttr::get(ReturnType.getContext(), ID, Name, ReturnType, InputTypes);
+      return FunctionTypeAttr::get(ReturnType.getContext(), ID, Name, ReturnType, InputTypes);
      }]>,
   ];
 

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.td
@@ -24,7 +24,7 @@ def Clift_FunctionArgumentAttr: Clift_Attr<"FunctionArgument", "farg", [DeclareA
   let parameters = (ins "mlir::clift::ValueType":$type, StringRefParameter<>:$name);
 
   let builders = [
-    AttrBuilderWithInferredContext<(ins "mlir::Type":$Type,
+    AttrBuilderWithInferredContext<(ins "mlir::clift::ValueType":$Type,
                                         CArg<"llvm::StringRef", "\"\"">:$Name), [{
       return $_get(Type.getContext(), Type, Name);
     }]>
@@ -41,15 +41,15 @@ def Clift_FieldAttr : Clift_Attr<"Field", "field", [DeclareAttrInterfaceMethods<
     A attribute representing a field of a struct or a union
   }];
 
-  let parameters = (ins "uint64_t":$offset, "mlir::Type":$type, StringRefParameter<>:$name);
+  let parameters = (ins "uint64_t":$offset, "mlir::clift::ValueType":$type, StringRefParameter<>:$name);
 
   let builders = [
     AttrBuilderWithInferredContext<(ins "uint64_t":$Offset,
-                                        "mlir::Type":$Type,
+                                        "mlir::clift::ValueType":$Type,
                                         CArg<"llvm::StringRef", "\"\"">:$Name), [{
       return $_get(Type.getContext(), Offset, Type, Name);
     }]>,
-    AttrBuilderWithInferredContext<(ins "mlir::Type":$Type,
+    AttrBuilderWithInferredContext<(ins "mlir::clift::ValueType":$Type,
                                         CArg<"llvm::StringRef", "\"\"">:$Name), [{
       return $_get(Type.getContext(), 0, Type, Name);
     }]>
@@ -76,10 +76,10 @@ def Clift_EnumFieldAttr : Clift_Attr<"EnumField", "enum_field", [DeclareAttrInte
 def Clift_EnumTypeAttr : Clift_Attr<"EnumType", "enum", [DeclareAttrInterfaceMethods<Clift_AliasableAttr>, DeclareAttrInterfaceMethods<Clift_SizedType, ["getByteSize"]>, Clift_TypeDefinitionAttr, SubElementAttrInterface]> {
   let summary = "Clift enum type";
 
-  let parameters = (ins "uint64_t":$id, StringRefParameter<>:$name, "mlir::Type":$underlying_type, ArrayRefParameter<"mlir::clift::EnumFieldAttr">:$fields);
+  let parameters = (ins "uint64_t":$id, StringRefParameter<>:$name, "mlir::clift::ValueType":$underlying_type, ArrayRefParameter<"mlir::clift::EnumFieldAttr">:$fields);
 
   let builders = [
-    TypeBuilderWithInferredContext<(ins "uint64_t":$ID, "llvm::StringRef":$Name, "mlir::Type":$ElementType, "llvm::ArrayRef<mlir::clift::EnumFieldAttr>":$Fields), [{
+    TypeBuilderWithInferredContext<(ins "uint64_t":$ID, "llvm::StringRef":$Name, "mlir::clift::ValueType":$ElementType, "llvm::ArrayRef<mlir::clift::EnumFieldAttr>":$Fields), [{
       return EnumTypeAttr::get(ElementType.getContext(), ID, Name, ElementType, Fields);
      }]>,
   ];
@@ -136,7 +136,7 @@ def Clift_ScalarTupleElementAttr : Clift_Attr<"ScalarTupleElement", "tuple_eleme
     An attribute representing an element of a scalar tuple
   }];
 
-  let parameters = (ins "mlir::Type":$type, StringRefParameter<>:$name);
+  let parameters = (ins "mlir::clift::ValueType":$type, StringRefParameter<>:$name);
 
   let genVerifyDecl = 1;
 

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftAttributes.td
@@ -15,7 +15,7 @@ class Clift_Attr<string name, string attrMnemonic, list<Trait> traits = []>
   let mnemonic = attrMnemonic;
 }
 
-def FunctionArgumentAttr: Clift_Attr<"FunctionArgument", "farg", [DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
+def Clift_FunctionArgumentAttr: Clift_Attr<"FunctionArgument", "farg", [DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
   let summary = "A attribute representing a argument of a function";
   let description = [{
     A attribute representing a argument of a function
@@ -35,7 +35,7 @@ def FunctionArgumentAttr: Clift_Attr<"FunctionArgument", "farg", [DeclareAttrInt
   let assemblyFormat = "`<`struct($name, $type)`>`";
 }
 
-def FieldAttr : Clift_Attr<"Field", "field", [DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
+def Clift_FieldAttr : Clift_Attr<"Field", "field", [DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
   let summary = "A attribute representing a field of a struct or a union";
   let description = [{
     A attribute representing a field of a struct or a union
@@ -60,7 +60,7 @@ def FieldAttr : Clift_Attr<"Field", "field", [DeclareAttrInterfaceMethods<SubEle
   let assemblyFormat = "`<`struct($offset, $name, $type)`>`";
 }
 
-def EnumFieldAttr : Clift_Attr<"EnumField", "enum_field", [DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
+def Clift_EnumFieldAttr : Clift_Attr<"EnumField", "enum_field", [DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
   let summary = "A attribute representing a field of enum";
   let description = [{
     A attribute representing a field of a struct or a union
@@ -73,7 +73,7 @@ def EnumFieldAttr : Clift_Attr<"EnumField", "enum_field", [DeclareAttrInterfaceM
   let assemblyFormat = "`<`struct($name, $raw_value)`>`";
 }
 
-def Clift_EnumTypeAttr : Clift_Attr<"EnumType", "enum", [DeclareAttrInterfaceMethods<AliasableAttr>, DeclareAttrInterfaceMethods<SizedType, ["getByteSize"]>, TypeDefinitionAttr, SubElementAttrInterface]> {
+def Clift_EnumTypeAttr : Clift_Attr<"EnumType", "enum", [DeclareAttrInterfaceMethods<Clift_AliasableAttr>, DeclareAttrInterfaceMethods<Clift_SizedType, ["getByteSize"]>, Clift_TypeDefinitionAttr, SubElementAttrInterface]> {
   let summary = "Clift enum type";
 
   let parameters = (ins "uint64_t":$id, StringRefParameter<>:$name, "mlir::Type":$underlying_type, ArrayRefParameter<"mlir::clift::EnumFieldAttr">:$fields);
@@ -92,7 +92,7 @@ def Clift_EnumTypeAttr : Clift_Attr<"EnumType", "enum", [DeclareAttrInterfaceMet
   let assemblyFormat = "`<`struct($id, $name, $underlying_type)  `,` `fields` `=` `[` $fields `]``>` ";
 }
 
-def Clift_TypedefTypeAttr: Clift_Attr<"TypedefType", "typedef", [DeclareAttrInterfaceMethods<AliasableAttr>, DeclareAttrInterfaceMethods<SizedType, ["getByteSize"]>, TypeDefinitionAttr, SubElementAttrInterface]> {
+def Clift_TypedefTypeAttr: Clift_Attr<"TypedefType", "typedef", [DeclareAttrInterfaceMethods<Clift_AliasableAttr>, DeclareAttrInterfaceMethods<Clift_SizedType, ["getByteSize"]>, Clift_TypeDefinitionAttr, SubElementAttrInterface]> {
   let summary = "Clift typedef type";
 
   let parameters = (ins "uint64_t":$id, StringRefParameter<>:$name, "mlir::clift::ValueType":$underlying_type);
@@ -111,7 +111,7 @@ def Clift_TypedefTypeAttr: Clift_Attr<"TypedefType", "typedef", [DeclareAttrInte
   let assemblyFormat = "`<`struct($id, $name, $underlying_type) `>` ";
 }
 
-def Clift_FunctionTypeAttr : Clift_Attr<"FunctionType", "function", [DeclareAttrInterfaceMethods<AliasableAttr>, DeclareAttrInterfaceMethods<SizedType, ["getByteSize"]>, TypeDefinitionAttr, SubElementAttrInterface]> {
+def Clift_FunctionTypeAttr : Clift_Attr<"FunctionType", "function", [DeclareAttrInterfaceMethods<Clift_AliasableAttr>, DeclareAttrInterfaceMethods<Clift_SizedType, ["getByteSize"]>, Clift_TypeDefinitionAttr, SubElementAttrInterface]> {
   let summary = "Clift function type";
 
   let parameters = (ins "uint64_t":$id, StringRefParameter<>:$name, "mlir::clift::ValueType":$return_type, OptionalArrayRefParameter<"mlir::clift::FunctionArgumentAttr">:$argument_types);
@@ -130,7 +130,7 @@ def Clift_FunctionTypeAttr : Clift_Attr<"FunctionType", "function", [DeclareAttr
   let assemblyFormat = "`<`struct($id, $name, $return_type) `,` `argument_types` `=` `[` (`]`) : ($argument_types^ `]`)?`>` ";
 }
 
-def ScalarTupleElementAttr : Clift_Attr<"ScalarTupleElement", "tuple_element", [DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
+def Clift_ScalarTupleElementAttr : Clift_Attr<"ScalarTupleElement", "tuple_element", [DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
   let summary = "An attribute representing an element of a scalar tuple";
   let description = [{
     An attribute representing an element of a scalar tuple

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftEnums.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftEnums.td
@@ -6,7 +6,7 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
 include "Clift.td"
 
-def PrimitiveKind: I32EnumAttr<"PrimitiveKind", "primitive type kinds", [
+def Clift_PrimitiveKind: I32EnumAttr<"PrimitiveKind", "primitive type kinds", [
     I32EnumAttrCase<"VoidKind", 1>,
     I32EnumAttrCase<"GenericKind", 2>,
     I32EnumAttrCase<"PointerOrNumberKind", 3>,

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftEnums.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftEnums.td
@@ -15,7 +15,7 @@ def PrimitiveKind: I32EnumAttr<"PrimitiveKind", "primitive type kinds", [
     I32EnumAttrCase<"SignedKind", 6>,
     I32EnumAttrCase<"FloatKind", 7>,
   ]> {
-  let cppNamespace = "::mlir::clift";
+  let cppNamespace = "mlir::clift";
   // since we want to wrap this enum into a clift type, do not generate
   // attribute wrapping it.
   let genSpecializedAttr = 0;

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
@@ -15,7 +15,7 @@ class Clift_AttrInterface<string name> : AttrInterface<name> {
     let cppNamespace = "mlir::clift";
 }
 
-def AliasableAttr: Clift_AttrInterface<"AliasableAttr"> {
+def Clift_AliasableAttr: Clift_AttrInterface<"AliasableAttr"> {
     let description = [{
       A Aliasable type is a type with a size and a constness
     }];
@@ -29,7 +29,7 @@ def AliasableAttr: Clift_AttrInterface<"AliasableAttr"> {
     ];
 }
 
-def AliasableType: Clift_TypeInterface<"AliasableType"> {
+def Clift_AliasableType: Clift_TypeInterface<"AliasableType"> {
     let description = [{
       A Aliasable type is a type with a size and a constness
     }];
@@ -43,7 +43,7 @@ def AliasableType: Clift_TypeInterface<"AliasableType"> {
     ];
 }
 
-def SizedType : Clift_AttrInterface<"SizedType"> {
+def Clift_SizedType : Clift_AttrInterface<"SizedType"> {
     let description = [{
       A sized type is a type with a size
     }];
@@ -59,7 +59,7 @@ def SizedType : Clift_AttrInterface<"SizedType"> {
     ];
 }
 
-def ValueType : Clift_TypeInterface<"ValueType"> {
+def Clift_ValueType : Clift_TypeInterface<"ValueType"> {
     let description = [{
       A value type is a type with a size and a constness
     }];
@@ -81,7 +81,7 @@ def ValueType : Clift_TypeInterface<"ValueType"> {
     ];
 }
 
-def TypeDefinitionAttr : Clift_AttrInterface<"TypeDefinitionAttr"> {
+def Clift_TypeDefinitionAttr : Clift_AttrInterface<"TypeDefinitionAttr"> {
     let description = [{
       A value type is a type with a ID and Name
     }];
@@ -104,6 +104,6 @@ def TypeDefinitionAttr : Clift_AttrInterface<"TypeDefinitionAttr"> {
 
 }
 
-def AnyValueType: Type<CPred<"llvm::isa<mlir::clift::ValueType>($_self)">, "cliftValue", "mlir::clift::ValueType">;
+def Clift_AnyValueType: Type<CPred<"llvm::isa<mlir::clift::ValueType>($_self)">, "cliftValue", "mlir::clift::ValueType">;
 #endif
 

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
@@ -81,7 +81,7 @@ def ValueType : Clift_TypeInterface<"ValueType"> {
     ];
 }
 
-def TypeDefinition : Clift_AttrInterface<"TypeDefinition"> {
+def TypeDefinitionAttr : Clift_AttrInterface<"TypeDefinitionAttr"> {
     let description = [{
       A value type is a type with a ID and Name
     }];

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
@@ -8,11 +8,11 @@
 include "mlir/IR/OpBase.td"
 
 class Clift_TypeInterface<string name> : TypeInterface<name> {
-    let cppNamespace = "::mlir::clift";
+    let cppNamespace = "mlir::clift";
 }
 
 class Clift_AttrInterface<string name> : AttrInterface<name> {
-    let cppNamespace = "::mlir::clift";
+    let cppNamespace = "mlir::clift";
 }
 
 def AliasableAttr: Clift_AttrInterface<"AliasableAttr"> {
@@ -104,6 +104,6 @@ def TypeDefinition : Clift_AttrInterface<"TypeDefinition"> {
 
 }
 
-def AnyValueType: Type<CPred<"::llvm::isa<::mlir::clift::ValueType>($_self)">, "cliftValue", "::mlir::clift::ValueType">;
+def AnyValueType: Type<CPred<"llvm::isa<mlir::clift::ValueType>($_self)">, "cliftValue", "mlir::clift::ValueType">;
 #endif
 

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftInterfaces.td
@@ -22,8 +22,8 @@ def Clift_AliasableAttr: Clift_AttrInterface<"AliasableAttr"> {
 
     let methods = [
         InterfaceMethod<
-            "returns the alias of the type.",
-            "std::string", "getAlias", (ins),
+            "Writes the alias to OS and returns true if it is non-empty.",
+            "bool", "getAlias", (ins "llvm::raw_ostream &":$OS),
             /*methodBody=*/[{}], /*defaultImplementation=*/[{}]
         >,
     ];
@@ -36,8 +36,8 @@ def Clift_AliasableType: Clift_TypeInterface<"AliasableType"> {
 
     let methods = [
         InterfaceMethod<
-            "returns the alias of the type.",
-            "std::string", "getAlias", (ins),
+            "Writes the alias to OS and returns true if it is non-empty.",
+            "bool", "getAlias", (ins "llvm::raw_ostream &":$OS),
             /*methodBody=*/[{}], /*defaultImplementation=*/[{}]
         >,
     ];

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftOps.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftOps.td
@@ -32,7 +32,7 @@ def Clift_LoopOp : Clift_Op<"loop", [Terminator]> {
 
 def Clift_ContinueOp : Clift_Op<"continue", [HasParent<"LoopOp">, Terminator]> {}
 
-def LabelResource : Resource<"LabelResource">;
+def Clift_LabelResource : Resource<"LabelResource">;
 
 def Clift_AssignLabelOp : Clift_Op<"assign_label"> {
   let arguments = (ins Arg<Clift_LabelType, "", [MemFree]>:$label);
@@ -154,7 +154,7 @@ Clift_FunctionBase<"function"> {
 }
 
 def Clift_UndefOp: Clift_Op<"undef"> {
-  let results = (outs AnyValueType:$result);
+  let results = (outs Clift_AnyValueType:$result);
 
   let assemblyFormat = [{
     type($result) attr-dict

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.h
@@ -77,7 +77,7 @@ public:
 
   [[nodiscard]] bool isComplete() const;
   [[nodiscard]] uint64_t getByteSize() const;
-  [[nodiscard]] std::string getAlias() const;
+  [[nodiscard]] bool getAlias(llvm::raw_ostream &OS) const;
   [[nodiscard]] BoolAttr getIsConst() const;
 
   static Type parse(AsmParser &Parser);

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.h
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.h
@@ -29,6 +29,9 @@ struct ScalarTupleTypeStorage;
 /// Scalar tuples are used to represent the multiple register return values of
 /// raw function types. They are much like structs, but permit only scalar
 /// element types and have no explicit offsets for their elements.
+///
+/// The scalar tuple type is intended as a temporary solution to be replaced in
+/// the future by auto-generated struct types.
 class ScalarTupleType : public Type::TypeBase<ScalarTupleType,
                                               Type,
                                               ScalarTupleTypeStorage,

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
@@ -23,7 +23,7 @@ def Clift_LabelType : Clift_Type<"Label", "label"> {
   }];
 }
 
-def Clift_PrimitiveType : Clift_Type<"Primitive", "primitive", [ValueType, DeclareTypeInterfaceMethods<AliasableType>]> {
+def Clift_PrimitiveType : Clift_Type<"Primitive", "primitive", [Clift_ValueType, DeclareTypeInterfaceMethods<Clift_AliasableType>]> {
   let summary = "Clift primitive type";
 
   let parameters = (ins "PrimitiveKind":$kind, "uint64_t":$size, DefaultValuedParameter<"BoolAttr", "BoolAttr::get($_ctxt, false)">:$is_const);
@@ -44,7 +44,7 @@ def Clift_PrimitiveType : Clift_Type<"Primitive", "primitive", [ValueType, Decla
 }
 
 
-def Clift_PointerType : Clift_Type<"Pointer", "pointer", [DeclareTypeInterfaceMethods<ValueType, ["getByteSize"]>, SubElementTypeInterface]> {
+def Clift_PointerType : Clift_Type<"Pointer", "pointer", [DeclareTypeInterfaceMethods<Clift_ValueType, ["getByteSize"]>, SubElementTypeInterface]> {
   let summary = "Clift pointer type";
 
   let parameters = (ins "mlir::clift::ValueType":$pointee_type, "uint64_t":$pointer_size, DefaultValuedParameter<"BoolAttr", "BoolAttr::get($_ctxt, false)">:$is_const);
@@ -58,7 +58,7 @@ def Clift_PointerType : Clift_Type<"Pointer", "pointer", [DeclareTypeInterfaceMe
   let assemblyFormat = "`<`( `is_const` `=` $is_const^ `,`` ` )? struct($pointee_type, $pointer_size) `>` ";
 }
 
-def DefinedType : Clift_Type<"Defined", "defined", [DeclareTypeInterfaceMethods<ValueType, ["getByteSize", "id"]>, SubElementTypeInterface, DeclareTypeInterfaceMethods<AliasableType>]> {
+def Clift_DefinedType : Clift_Type<"Defined", "defined", [DeclareTypeInterfaceMethods<Clift_ValueType, ["getByteSize", "id"]>, SubElementTypeInterface, DeclareTypeInterfaceMethods<Clift_AliasableType>]> {
   let summary = "Clift nominal type";
 
   let parameters = (ins "mlir::clift::TypeDefinitionAttr":$element_type, DefaultValuedParameter<"BoolAttr", "BoolAttr::get($_ctxt, false)">:$is_const);
@@ -79,7 +79,7 @@ def DefinedType : Clift_Type<"Defined", "defined", [DeclareTypeInterfaceMethods<
   let assemblyFormat = "`<`( `is_const` `=` $is_const^ `,`` ` )? $element_type `>` ";
 }
 
-def Clift_ArrayType : Clift_Type<"Array", "array", [DeclareTypeInterfaceMethods<ValueType, ["getByteSize"]>, SubElementTypeInterface]> {
+def Clift_ArrayType : Clift_Type<"Array", "array", [DeclareTypeInterfaceMethods<Clift_ValueType, ["getByteSize"]>, SubElementTypeInterface]> {
   let summary = "Clift Array type";
 
   let parameters = (ins "mlir::clift::ValueType":$element_type, "uint64_t":$elements_count, DefaultValuedParameter<"BoolAttr", "BoolAttr::get($_ctxt, false)">:$is_const);

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
@@ -43,7 +43,6 @@ def Clift_PrimitiveType : Clift_Type<"Primitive", "primitive", [Clift_ValueType,
   let assemblyFormat = "`<`( `is_const` `=` $is_const^ `,`` `)? $kind $size `>` ";
 }
 
-
 def Clift_PointerType : Clift_Type<"Pointer", "pointer", [DeclareTypeInterfaceMethods<Clift_ValueType, ["getByteSize"]>, SubElementTypeInterface]> {
   let summary = "Clift pointer type";
 
@@ -91,4 +90,3 @@ def Clift_ArrayType : Clift_Type<"Array", "array", [DeclareTypeInterfaceMethods<
 
   let assemblyFormat = "`<`( `is_const` `=` $is_const^ `,`` ` )? struct($element_type, $elements_count) `>` ";
 }
-

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
@@ -43,6 +43,7 @@ def Clift_PrimitiveType : Clift_Type<"Primitive", "primitive", [Clift_ValueType,
   let assemblyFormat = "`<`( `is_const` `=` $is_const^ `,`` `)? $kind $size `>` ";
 }
 
+
 def Clift_PointerType : Clift_Type<"Pointer", "pointer", [DeclareTypeInterfaceMethods<Clift_ValueType, ["getByteSize"]>, SubElementTypeInterface]> {
   let summary = "Clift pointer type";
 

--- a/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
+++ b/include/revng-c/mlir/Dialect/Clift/IR/CliftTypes.td
@@ -61,10 +61,10 @@ def Clift_PointerType : Clift_Type<"Pointer", "pointer", [DeclareTypeInterfaceMe
 def DefinedType : Clift_Type<"Defined", "defined", [DeclareTypeInterfaceMethods<ValueType, ["getByteSize", "id"]>, SubElementTypeInterface, DeclareTypeInterfaceMethods<AliasableType>]> {
   let summary = "Clift nominal type";
 
-  let parameters = (ins "mlir::clift::TypeDefinition":$element_type, DefaultValuedParameter<"BoolAttr", "BoolAttr::get($_ctxt, false)">:$is_const);
+  let parameters = (ins "mlir::clift::TypeDefinitionAttr":$element_type, DefaultValuedParameter<"BoolAttr", "BoolAttr::get($_ctxt, false)">:$is_const);
 
   let description = [{
-     A defined type wraps a TypeDefinition attribute so that it can be attached
+     A defined type wraps a TypeDefinitionAttr attribute so that it can be attached
      to values. Defined type exists because we are mirroring the revng model
      type hierarchy which has the same concept. TypeDefinitions are attributes
      to prevent them from being attached to values without being wrapped into

--- a/lib/mlir/Dialect/Clift/IR/Clift.cpp
+++ b/lib/mlir/Dialect/Clift/IR/Clift.cpp
@@ -17,24 +17,18 @@ public:
 
   AliasResult getAlias(mlir::Attribute Attr,
                        llvm::raw_ostream &OS) const final {
-    if (auto Casted = Attr.dyn_cast<mlir::clift::AliasableAttr>()) {
-      if (not Casted.getAlias().empty()) {
-        OS << Casted.getAlias();
+    if (auto Aliasable = mlir::dyn_cast<mlir::clift::AliasableAttr>(Attr)) {
+      if (Aliasable.getAlias(OS))
         return AliasResult::FinalAlias;
-      }
     }
-
     return AliasResult::NoAlias;
   }
 
   AliasResult getAlias(mlir::Type Type, llvm::raw_ostream &OS) const final {
-    if (auto Casted = Type.dyn_cast<mlir::clift::AliasableType>()) {
-      if (not Casted.getAlias().empty()) {
-        OS << Casted.getAlias();
+    if (auto Aliasable = mlir::dyn_cast<mlir::clift::AliasableType>(Type)) {
+      if (Aliasable.getAlias(OS))
         return AliasResult::FinalAlias;
-      }
     }
-
     return AliasResult::NoAlias;
   }
 };

--- a/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
@@ -26,9 +26,11 @@
 #define GET_ATTRDEF_CLASSES
 #include "revng-c/mlir/Dialect/Clift/IR/CliftAttributes.cpp.inc"
 
+using namespace mlir::clift;
+
 using EmitErrorType = llvm::function_ref<mlir::InFlightDiagnostic()>;
 
-void mlir::clift::CliftDialect::registerAttributes() {
+void CliftDialect::registerAttributes() {
   addAttributes<StructTypeAttr, UnionTypeAttr,
 
   // Include the list of auto-generated attributes
@@ -37,16 +39,15 @@ void mlir::clift::CliftDialect::registerAttributes() {
                 /* End of auto-generated list */>();
 }
 
-mlir::LogicalResult mlir::clift::FieldAttr::verify(EmitErrorType EmitError,
-                                                   uint64_t Offset,
-                                                   mlir::Type ElementType,
-                                                   llvm::StringRef Name) {
-  if (auto Definition = mlir::dyn_cast<mlir::clift::DefinedType>(ElementType))
-    if (mlir::isa<mlir::clift::FunctionTypeAttr>(Definition.getElementType()))
+mlir::LogicalResult FieldAttr::verify(EmitErrorType EmitError,
+                                      uint64_t Offset,
+                                      mlir::Type ElementType,
+                                      llvm::StringRef Name) {
+  if (auto Definition = mlir::dyn_cast<DefinedType>(ElementType))
+    if (mlir::isa<FunctionTypeAttr>(Definition.getElementType()))
       return EmitError() << "Underlying type of field attr cannot be a "
                             "function type";
-  mlir::clift::ValueType
-    Casted = mlir::dyn_cast<mlir::clift::ValueType>(ElementType);
+  clift::ValueType Casted = mlir::dyn_cast<clift::ValueType>(ElementType);
   if (Casted == nullptr) {
     return EmitError() << "Underlying type of a field attr must be a value "
                           "type";
@@ -57,41 +58,35 @@ mlir::LogicalResult mlir::clift::FieldAttr::verify(EmitErrorType EmitError,
   return mlir::success();
 }
 
-using EnumFieldAttr = mlir::clift::EnumFieldAttr;
 mlir::LogicalResult EnumFieldAttr::verify(EmitErrorType EmitError,
                                           uint64_t RawValue,
                                           llvm::StringRef Name) {
   return mlir::success();
 }
 
-using TypedefTypeAttr = mlir::clift::TypedefTypeAttr;
-mlir::LogicalResult
-TypedefTypeAttr::verify(EmitErrorType EmitError,
-                        uint64_t Id,
-                        llvm::StringRef Name,
-                        mlir::clift::ValueType UnderlyingType) {
+mlir::LogicalResult TypedefTypeAttr::verify(EmitErrorType EmitError,
+                                            uint64_t Id,
+                                            llvm::StringRef Name,
+                                            clift::ValueType UnderlyingType) {
   return mlir::success();
 }
 
-using ArgAttr = mlir::clift::FunctionArgumentAttr;
-mlir::LogicalResult ArgAttr::verify(EmitErrorType EmitError,
-                                    mlir::clift::ValueType underlying,
-                                    llvm::StringRef Name) {
+mlir::LogicalResult FunctionArgumentAttr::verify(EmitErrorType EmitError,
+                                                 clift::ValueType underlying,
+                                                 llvm::StringRef Name) {
   if (underlying.getByteSize() == 0) {
     return EmitError() << "type of argument of function cannot be zero size";
   }
   return mlir::success();
 }
 
-using mlir::clift::FunctionTypeAttr;
 mlir::LogicalResult
 FunctionTypeAttr::verify(EmitErrorType EmitError,
                          uint64_t Id,
                          llvm::StringRef,
-                         mlir::clift::ValueType ReturnType,
-                         llvm::ArrayRef<mlir::clift::FunctionArgumentAttr>
-                           Args) {
-  if (auto Type = mlir::dyn_cast<mlir::clift::DefinedType>(ReturnType)) {
+                         clift::ValueType ReturnType,
+                         llvm::ArrayRef<FunctionArgumentAttr> Args) {
+  if (auto Type = mlir::dyn_cast<DefinedType>(ReturnType)) {
     if (mlir::isa<FunctionTypeAttr>(Type.getElementType()))
       return EmitError() << "function type cannot return another function type";
   }
@@ -109,9 +104,8 @@ FunctionTypeAttr::verify(EmitErrorType EmitError,
 }
 
 /// Parse a type registered to this dialect
-mlir::Attribute
-mlir::clift::CliftDialect::parseAttribute(mlir::DialectAsmParser &Parser,
-                                          mlir::Type Type) const {
+mlir::Attribute CliftDialect::parseAttribute(mlir::DialectAsmParser &Parser,
+                                             mlir::Type Type) const {
   llvm::SMLoc typeLoc = Parser.getCurrentLocation();
   llvm::StringRef Mnemonic;
   mlir::Attribute GenAttr;
@@ -132,9 +126,8 @@ mlir::clift::CliftDialect::parseAttribute(mlir::DialectAsmParser &Parser,
 }
 
 /// Print a type registered to this dialect
-void mlir::clift::CliftDialect::printAttribute(mlir::Attribute Attr,
-                                               mlir::DialectAsmPrinter &Printer)
-  const {
+void CliftDialect::printAttribute(mlir::Attribute Attr,
+                                  mlir::DialectAsmPrinter &Printer) const {
 
   if (mlir::succeeded(generatedAttributePrinter(Attr, Printer)))
     return;
@@ -149,49 +142,49 @@ void mlir::clift::CliftDialect::printAttribute(mlir::Attribute Attr,
   revng_abort("cannot print attribute");
 }
 
-void mlir::clift::UnionTypeAttr::print(AsmPrinter &Printer) const {
+void UnionTypeAttr::print(AsmPrinter &Printer) const {
   printCompositeType(Printer, *this);
 }
 
-void mlir::clift::StructTypeAttr::print(AsmPrinter &Printer) const {
+void StructTypeAttr::print(AsmPrinter &Printer) const {
   printCompositeType(Printer, *this);
 }
 
-mlir::Attribute mlir::clift::UnionTypeAttr::parse(AsmParser &Parser) {
+mlir::Attribute UnionTypeAttr::parse(AsmParser &Parser) {
   return parseCompositeType<UnionTypeAttr>(Parser, /*MinSubobjects=*/1);
 }
 
-mlir::Attribute mlir::clift::StructTypeAttr::parse(AsmParser &Parser) {
+mlir::Attribute StructTypeAttr::parse(AsmParser &Parser) {
   return parseCompositeType<StructTypeAttr>(Parser, /*MinSubobjects=*/0);
 }
 
 static bool isCompleteType(const mlir::Type Type) {
-  if (auto T = mlir::dyn_cast<mlir::clift::DefinedType>(Type)) {
+  if (auto T = mlir::dyn_cast<DefinedType>(Type)) {
     auto Definition = T.getElementType();
-    if (auto D = mlir::dyn_cast<mlir::clift::StructTypeAttr>(Definition))
+    if (auto D = mlir::dyn_cast<StructTypeAttr>(Definition))
       return D.isDefinition();
-    if (auto D = mlir::dyn_cast<mlir::clift::UnionTypeAttr>(Definition))
+    if (auto D = mlir::dyn_cast<UnionTypeAttr>(Definition))
       return D.isDefinition();
     return true;
   }
 
-  if (auto T = mlir::dyn_cast<mlir::clift::ScalarTupleType>(Type))
+  if (auto T = mlir::dyn_cast<ScalarTupleType>(Type))
     return T.isComplete();
 
   return true;
 }
 
-mlir::LogicalResult mlir::clift::StructTypeAttr::verify(EmitErrorType EmitError,
-                                                        uint64_t ID) {
+mlir::LogicalResult StructTypeAttr::verify(EmitErrorType EmitError,
+                                           uint64_t ID) {
   return mlir::success();
 }
 
 mlir::LogicalResult
-mlir::clift::StructTypeAttr::verify(const EmitErrorType EmitError,
-                                    const uint64_t ID,
-                                    const llvm::StringRef Name,
-                                    const uint64_t Size,
-                                    const llvm::ArrayRef<FieldAttr> Fields) {
+StructTypeAttr::verify(const EmitErrorType EmitError,
+                       const uint64_t ID,
+                       const llvm::StringRef Name,
+                       const uint64_t Size,
+                       const llvm::ArrayRef<FieldAttr> Fields) {
   if (Size == 0)
     return EmitError() << "struct type cannot have a size of zero";
 
@@ -209,9 +202,7 @@ mlir::clift::StructTypeAttr::verify(const EmitErrorType EmitError,
                               "they cannot overlap";
 
       LastEndOffset = Field.getOffset()
-                      + Field.getType()
-                          .cast<mlir::clift::ValueType>()
-                          .getByteSize();
+                      + Field.getType().cast<clift::ValueType>().getByteSize();
 
       if (not Field.getName().empty()) {
         if (not NameSet.insert(Field.getName()).second)
@@ -227,16 +218,15 @@ mlir::clift::StructTypeAttr::verify(const EmitErrorType EmitError,
   return mlir::success();
 }
 
-mlir::LogicalResult mlir::clift::UnionTypeAttr::verify(EmitErrorType EmitError,
-                                                       uint64_t ID) {
+mlir::LogicalResult UnionTypeAttr::verify(EmitErrorType EmitError,
+                                          uint64_t ID) {
   return mlir::success();
 }
 
-mlir::LogicalResult
-mlir::clift::UnionTypeAttr::verify(EmitErrorType EmitError,
-                                   uint64_t ID,
-                                   llvm::StringRef,
-                                   llvm::ArrayRef<FieldAttr> Fields) {
+mlir::LogicalResult UnionTypeAttr::verify(EmitErrorType EmitError,
+                                          uint64_t ID,
+                                          llvm::StringRef,
+                                          llvm::ArrayRef<FieldAttr> Fields) {
   if (Fields.empty())
     return EmitError() << "union types must have at least one field";
 
@@ -257,78 +247,69 @@ mlir::clift::UnionTypeAttr::verify(EmitErrorType EmitError,
   return mlir::success();
 }
 
-mlir::clift::StructTypeAttr
-mlir::clift::StructTypeAttr::get(MLIRContext *Context, uint64_t ID) {
+StructTypeAttr StructTypeAttr::get(MLIRContext *Context, uint64_t ID) {
   return Base::get(Context, ID);
 }
 
-mlir::clift::StructTypeAttr
-mlir::clift::StructTypeAttr::getChecked(EmitErrorType EmitError,
-                                        MLIRContext *Context,
-                                        uint64_t ID) {
+StructTypeAttr StructTypeAttr::getChecked(EmitErrorType EmitError,
+                                          MLIRContext *Context,
+                                          uint64_t ID) {
   return get(Context, ID);
 }
 
-mlir::clift::StructTypeAttr
-mlir::clift::StructTypeAttr::get(MLIRContext *Context,
-                                 uint64_t ID,
-                                 llvm::StringRef Name,
-                                 uint64_t Size,
-                                 llvm::ArrayRef<FieldAttr> Fields) {
+StructTypeAttr StructTypeAttr::get(MLIRContext *Context,
+                                   uint64_t ID,
+                                   llvm::StringRef Name,
+                                   uint64_t Size,
+                                   llvm::ArrayRef<FieldAttr> Fields) {
   auto Result = Base::get(Context, ID);
   Result.define(Name, Size, Fields);
   return Result;
 }
 
-mlir::clift::StructTypeAttr
-mlir::clift::StructTypeAttr::getChecked(EmitErrorType EmitError,
-                                        MLIRContext *Context,
-                                        uint64_t ID,
-                                        llvm::StringRef Name,
-                                        uint64_t Size,
-                                        llvm::ArrayRef<FieldAttr> Fields) {
+StructTypeAttr StructTypeAttr::getChecked(EmitErrorType EmitError,
+                                          MLIRContext *Context,
+                                          uint64_t ID,
+                                          llvm::StringRef Name,
+                                          uint64_t Size,
+                                          llvm::ArrayRef<FieldAttr> Fields) {
   if (failed(verify(EmitError, ID, Name, Size, Fields)))
     return {};
   return get(Context, ID, Name, Size, Fields);
 }
 
-mlir::clift::UnionTypeAttr mlir::clift::UnionTypeAttr::get(MLIRContext *Context,
-                                                           uint64_t ID) {
+UnionTypeAttr UnionTypeAttr::get(MLIRContext *Context, uint64_t ID) {
   return Base::get(Context, ID);
 }
 
-mlir::clift::UnionTypeAttr
-mlir::clift::UnionTypeAttr::getChecked(EmitErrorType EmitError,
-                                       MLIRContext *Context,
-                                       uint64_t ID) {
+UnionTypeAttr UnionTypeAttr::getChecked(EmitErrorType EmitError,
+                                        MLIRContext *Context,
+                                        uint64_t ID) {
   return get(Context, ID);
 }
 
-mlir::clift::UnionTypeAttr
-mlir::clift::UnionTypeAttr::get(MLIRContext *Context,
-                                uint64_t ID,
-                                llvm::StringRef Name,
-                                llvm::ArrayRef<FieldAttr> Fields) {
+UnionTypeAttr UnionTypeAttr::get(MLIRContext *Context,
+                                 uint64_t ID,
+                                 llvm::StringRef Name,
+                                 llvm::ArrayRef<FieldAttr> Fields) {
   auto Result = Base::get(Context, ID);
   Result.define(Name, Fields);
   return Result;
 }
 
-mlir::clift::UnionTypeAttr
-mlir::clift::UnionTypeAttr::getChecked(EmitErrorType EmitError,
-                                       MLIRContext *Context,
-                                       uint64_t ID,
-                                       llvm::StringRef Name,
-                                       llvm::ArrayRef<FieldAttr> Fields) {
+UnionTypeAttr UnionTypeAttr::getChecked(EmitErrorType EmitError,
+                                        MLIRContext *Context,
+                                        uint64_t ID,
+                                        llvm::StringRef Name,
+                                        llvm::ArrayRef<FieldAttr> Fields) {
   if (failed(verify(EmitError, ID, Name, Fields)))
     return {};
   return get(Context, ID, Name, Fields);
 }
 
-void mlir::clift::StructTypeAttr::define(const llvm::StringRef Name,
-                                         const uint64_t Size,
-                                         const llvm::ArrayRef<FieldAttr>
-                                           Fields) {
+void StructTypeAttr::define(const llvm::StringRef Name,
+                            const uint64_t Size,
+                            const llvm::ArrayRef<FieldAttr> Fields) {
   // Call into the base to mutate the type.
   LogicalResult Result = Base::mutate(Name, Fields, Size);
 
@@ -339,9 +320,8 @@ void mlir::clift::StructTypeAttr::define(const llvm::StringRef Name,
                   "type");
 }
 
-void mlir::clift::UnionTypeAttr::define(const llvm::StringRef Name,
-                                        const llvm::ArrayRef<FieldAttr>
-                                          Fields) {
+void UnionTypeAttr::define(const llvm::StringRef Name,
+                           const llvm::ArrayRef<FieldAttr> Fields) {
   // Call into the base to mutate the type.
   LogicalResult Result = Base::mutate(Name, Fields);
 
@@ -352,69 +332,67 @@ void mlir::clift::UnionTypeAttr::define(const llvm::StringRef Name,
                   "type");
 }
 
-uint64_t mlir::clift::StructTypeAttr::getId() const {
+uint64_t StructTypeAttr::getId() const {
   return getImpl()->getID();
 }
 
-llvm::StringRef mlir::clift::StructTypeAttr::getName() const {
+llvm::StringRef StructTypeAttr::getName() const {
   return getImpl()->getName();
 }
 
-llvm::ArrayRef<mlir::clift::FieldAttr>
-mlir::clift::StructTypeAttr::getFields() const {
+llvm::ArrayRef<FieldAttr> StructTypeAttr::getFields() const {
   return getImpl()->getSubobjects();
 }
 
-bool mlir::clift::StructTypeAttr::isDefinition() const {
+bool StructTypeAttr::isDefinition() const {
   return getImpl()->isInitialized();
 }
 
-uint64_t mlir::clift::StructTypeAttr::getByteSize() const {
+uint64_t StructTypeAttr::getByteSize() const {
   return getImpl()->getSize();
 }
 
-std::string mlir::clift::StructTypeAttr::getAlias() const {
+std::string StructTypeAttr::getAlias() const {
   return getName().str();
 }
 
-uint64_t mlir::clift::UnionTypeAttr::getId() const {
+uint64_t UnionTypeAttr::getId() const {
   return getImpl()->getID();
 }
 
-llvm::StringRef mlir::clift::UnionTypeAttr::getName() const {
+llvm::StringRef UnionTypeAttr::getName() const {
   return getImpl()->getName();
 }
 
-llvm::ArrayRef<mlir::clift::FieldAttr>
-mlir::clift::UnionTypeAttr::getFields() const {
+llvm::ArrayRef<FieldAttr> UnionTypeAttr::getFields() const {
   return getImpl()->getSubobjects();
 }
 
-bool mlir::clift::UnionTypeAttr::isDefinition() const {
+bool UnionTypeAttr::isDefinition() const {
   return getImpl()->isInitialized();
 }
 
-uint64_t mlir::clift::UnionTypeAttr::getByteSize() const {
+uint64_t UnionTypeAttr::getByteSize() const {
   uint64_t Max = 0;
   for (const auto &Field : getFields()) {
     mlir::Type FieldType = Field.getType();
-    uint64_t Size = FieldType.cast<mlir::clift::ValueType>().getByteSize();
+    uint64_t Size = FieldType.cast<clift::ValueType>().getByteSize();
     Max = Size > Max ? Size : Max;
   }
   return Max;
 }
 
-std::string mlir::clift::UnionTypeAttr::getAlias() const {
+std::string UnionTypeAttr::getAlias() const {
   return getName().str();
 }
 
 //************************** ScalarTupleElementAttr ****************************
 
 mlir::LogicalResult
-mlir::clift::ScalarTupleElementAttr::verify(const EmitErrorType EmitError,
-                                            mlir::Type Type,
-                                            const llvm::StringRef Name) {
-  if (not mlir::isa<mlir::clift::ValueType>(Type))
+ScalarTupleElementAttr::verify(const EmitErrorType EmitError,
+                               mlir::Type Type,
+                               const llvm::StringRef Name) {
+  if (not mlir::isa<clift::ValueType>(Type))
     return EmitError() << "Scalar tuple element type must be a value type";
 
   return mlir::success();

--- a/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
@@ -42,7 +42,7 @@ mlir::LogicalResult mlir::clift::FieldAttr::verify(EmitErrorType EmitError,
                                                    mlir::Type ElementType,
                                                    llvm::StringRef Name) {
   if (auto Definition = mlir::dyn_cast<mlir::clift::DefinedType>(ElementType))
-    if (mlir::isa<mlir::clift::FunctionAttr>(Definition.getElementType()))
+    if (mlir::isa<mlir::clift::FunctionTypeAttr>(Definition.getElementType()))
       return EmitError() << "Underlying type of field attr cannot be a "
                             "function type";
   mlir::clift::ValueType
@@ -64,11 +64,12 @@ mlir::LogicalResult EnumFieldAttr::verify(EmitErrorType EmitError,
   return mlir::success();
 }
 
-using TypedefAttr = mlir::clift::TypedefAttr;
-mlir::LogicalResult TypedefAttr::verify(EmitErrorType EmitError,
-                                        uint64_t Id,
-                                        llvm::StringRef Name,
-                                        mlir::clift::ValueType UnderlyingType) {
+using TypedefTypeAttr = mlir::clift::TypedefTypeAttr;
+mlir::LogicalResult
+TypedefTypeAttr::verify(EmitErrorType EmitError,
+                        uint64_t Id,
+                        llvm::StringRef Name,
+                        mlir::clift::ValueType UnderlyingType) {
   return mlir::success();
 }
 
@@ -82,18 +83,16 @@ mlir::LogicalResult ArgAttr::verify(EmitErrorType EmitError,
   return mlir::success();
 }
 
-using FunctionAttr = mlir::clift::FunctionAttr;
+using mlir::clift::FunctionTypeAttr;
 mlir::LogicalResult
-FunctionAttr::verify(EmitErrorType EmitError,
-                     uint64_t Id,
-                     llvm::StringRef Name,
-                     mlir::clift::ValueType ReturnType,
-                     llvm::ArrayRef<mlir::clift::FunctionArgumentAttr> Args) {
-  if (mlir::clift::DefinedType
-        Type = mlir::dyn_cast<mlir::clift::DefinedType>(ReturnType)) {
-    using FunctionAttr = mlir::clift::FunctionAttr;
-    if (mlir::clift::FunctionAttr
-          Definition = mlir::dyn_cast<FunctionAttr>(Type.getElementType()))
+FunctionTypeAttr::verify(EmitErrorType EmitError,
+                         uint64_t Id,
+                         llvm::StringRef,
+                         mlir::clift::ValueType ReturnType,
+                         llvm::ArrayRef<mlir::clift::FunctionArgumentAttr>
+                           Args) {
+  if (auto Type = mlir::dyn_cast<mlir::clift::DefinedType>(ReturnType)) {
+    if (mlir::isa<FunctionTypeAttr>(Type.getElementType()))
       return EmitError() << "function type cannot return another function type";
   }
   std::set<llvm::StringRef> Names;

--- a/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
@@ -189,8 +189,11 @@ uint64_t EnumTypeAttr::getByteSize() const {
   return mlir::cast<PrimitiveType>(getUnderlyingType()).getSize();
 }
 
-std::string EnumTypeAttr::getAlias() const {
-  return getName().str();
+bool EnumTypeAttr::getAlias(llvm::raw_ostream &OS) const {
+  if (getName().empty())
+    return false;
+  OS << getName() << "$def";
+  return true;
 }
 
 //===--------------------------- TypedefTypeAttr --------------------------===//
@@ -206,8 +209,11 @@ uint64_t TypedefTypeAttr::getByteSize() const {
   return getUnderlyingType().getByteSize();
 }
 
-std::string TypedefTypeAttr::getAlias() const {
-  return getName().str();
+bool TypedefTypeAttr::getAlias(llvm::raw_ostream &OS) const {
+  if (getName().empty())
+    return false;
+  OS << getName() << "$def";
+  return true;
 }
 
 //===------------------------ FunctionArgumentAttr ------------------------===//
@@ -245,8 +251,11 @@ uint64_t FunctionTypeAttr::getByteSize() const {
   return 0;
 }
 
-std::string FunctionTypeAttr::getAlias() const {
-  return getName().str();
+bool FunctionTypeAttr::getAlias(llvm::raw_ostream &OS) const {
+  if (getName().empty())
+    return false;
+  OS << getName() << "$def";
+  return true;
 }
 
 //===----------------------- ScalarTupleElementAttr -----------------------===//
@@ -367,8 +376,11 @@ uint64_t StructTypeAttr::getByteSize() const {
   return getImpl()->getSize();
 }
 
-std::string StructTypeAttr::getAlias() const {
-  return getName().str();
+bool StructTypeAttr::getAlias(llvm::raw_ostream &OS) const {
+  if (getName().empty())
+    return false;
+  OS << getName() << "$def";
+  return true;
 }
 
 mlir::Attribute StructTypeAttr::parse(AsmParser &Parser) {
@@ -489,8 +501,11 @@ uint64_t UnionTypeAttr::getByteSize() const {
   return Max;
 }
 
-std::string UnionTypeAttr::getAlias() const {
-  return getName().str();
+bool UnionTypeAttr::getAlias(llvm::raw_ostream &OS) const {
+  if (getName().empty())
+    return false;
+  OS << getName() << "$def";
+  return true;
 }
 
 mlir::Attribute UnionTypeAttr::parse(AsmParser &Parser) {

--- a/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftAttributes.cpp
@@ -109,12 +109,12 @@ FunctionAttr::verify(EmitErrorType EmitError,
 }
 
 /// Parse a type registered to this dialect
-::mlir::Attribute
-mlir::clift::CliftDialect::parseAttribute(::mlir::DialectAsmParser &Parser,
+mlir::Attribute
+mlir::clift::CliftDialect::parseAttribute(mlir::DialectAsmParser &Parser,
                                           mlir::Type Type) const {
-  ::llvm::SMLoc typeLoc = Parser.getCurrentLocation();
-  ::llvm::StringRef Mnemonic;
-  ::mlir::Attribute GenAttr;
+  llvm::SMLoc typeLoc = Parser.getCurrentLocation();
+  llvm::StringRef Mnemonic;
+  mlir::Attribute GenAttr;
 
   auto ParseResult = generatedAttributeParser(Parser, &Mnemonic, Type, GenAttr);
   if (ParseResult.has_value())
@@ -132,11 +132,11 @@ mlir::clift::CliftDialect::parseAttribute(::mlir::DialectAsmParser &Parser,
 }
 
 /// Print a type registered to this dialect
-void mlir::clift::CliftDialect::printAttribute(::mlir::Attribute Attr,
-                                               ::mlir::DialectAsmPrinter
-                                                 &Printer) const {
+void mlir::clift::CliftDialect::printAttribute(mlir::Attribute Attr,
+                                               mlir::DialectAsmPrinter &Printer)
+  const {
 
-  if (::mlir::succeeded(generatedAttributePrinter(Attr, Printer)))
+  if (mlir::succeeded(generatedAttributePrinter(Attr, Printer)))
     return;
   if (auto Casted = Attr.dyn_cast<StructType>()) {
     Casted.print(Printer);

--- a/lib/mlir/Dialect/Clift/IR/CliftOps.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftOps.cpp
@@ -189,7 +189,7 @@ struct ModuleValidator {
 private:
   llvm::SmallPtrSet<mlir::Type, 2> VisistedTypes;
   llvm::SmallPtrSet<mlir::Attribute, 2> VisitedAttrs;
-  llvm::DenseMap<size_t, mlir::clift::TypeDefinitionAttr> Definitions;
+  llvm::DenseMap<uint64_t, mlir::clift::TypeDefinitionAttr> Definitions;
 };
 
 mlir::LogicalResult mlir::clift::ModuleOp::verify() {

--- a/lib/mlir/Dialect/Clift/IR/CliftOps.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftOps.cpp
@@ -91,7 +91,7 @@ struct ModuleValidator {
     if (checkTypeIsAcceptable(Type, ContainingOp).failed())
       return mlir::failure();
 
-    auto Casted = Type.dyn_cast<mlir::clift::DefinedType>();
+    auto Casted = mlir::dyn_cast<mlir::clift::DefinedType>(Type);
     if (not Casted)
       return mlir::success();
     if (auto Iter = Definitions.find(Casted.id());
@@ -114,7 +114,7 @@ struct ModuleValidator {
     if (visitSingleType(ContainingOp, Type).failed())
       return mlir::failure();
 
-    auto Casted = Type.dyn_cast<mlir::SubElementTypeInterface>();
+    auto Casted = mlir::dyn_cast<mlir::SubElementTypeInterface>(Type);
     if (not Casted) {
       return mlir::success();
     }
@@ -137,7 +137,7 @@ struct ModuleValidator {
       return mlir::success();
     VisitedAttrs.insert(Attr);
 
-    auto Casted = Attr.dyn_cast<mlir::SubElementAttrInterface>();
+    auto Casted = mlir::dyn_cast<mlir::SubElementAttrInterface>(Attr);
     if (not Casted) {
       return mlir::success();
     }
@@ -156,8 +156,8 @@ struct ModuleValidator {
 
   mlir::LogicalResult checkTypeIsAcceptable(mlir::Type Type,
                                             mlir::Operation *Op) {
-    if (not Type.isa<mlir::clift::LabelType>()
-        and not Type.isa<mlir::clift::ValueType>()) {
+    if (not mlir::isa<mlir::clift::LabelType>(Type)
+        and not mlir::isa<mlir::clift::ValueType>(Type)) {
       Op->emitError("Only label types and value types are accepted in a "
                     "clift module value");
       return mlir::failure();

--- a/lib/mlir/Dialect/Clift/IR/CliftOps.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftOps.cpp
@@ -189,7 +189,7 @@ struct ModuleValidator {
 private:
   llvm::SmallPtrSet<mlir::Type, 2> VisistedTypes;
   llvm::SmallPtrSet<mlir::Attribute, 2> VisitedAttrs;
-  llvm::DenseMap<size_t, mlir::clift::TypeDefinition> Definitions;
+  llvm::DenseMap<size_t, mlir::clift::TypeDefinitionAttr> Definitions;
 };
 
 mlir::LogicalResult mlir::clift::ModuleOp::verify() {

--- a/lib/mlir/Dialect/Clift/IR/CliftParser.h
+++ b/lib/mlir/Dialect/Clift/IR/CliftParser.h
@@ -141,18 +141,18 @@ ObjectT parseCompositeType(AsmParser &Parser, const size_t MinSubobjects) {
   Iterator->second = Object.getImpl();
 
   using SubobjectType = typename ObjectT::ImplType::SubobjectTy;
-  using SubobjectVectorType = ::llvm::SmallVector<SubobjectType>;
-  using SubobjectParserType = ::mlir::FieldParser<SubobjectVectorType>;
-  ::mlir::FailureOr<SubobjectVectorType> Subobjects(SubobjectVectorType{});
+  using SubobjectVectorType = llvm::SmallVector<SubobjectType>;
+  using SubobjectParserType = mlir::FieldParser<SubobjectVectorType>;
+  mlir::FailureOr<SubobjectVectorType> Subobjects(SubobjectVectorType{});
 
   if (MinSubobjects > 0 or Parser.parseOptionalRSquare().failed()) {
     Subobjects = SubobjectParserType::parse(Parser);
 
-    if (::mlir::failed(Subobjects)) {
+    if (mlir::failed(Subobjects)) {
       Parser.emitError(Parser.getCurrentLocation(),
                        "failed to parse class type parameter 'fields' "
                        "which is to be a "
-                       "`::llvm::ArrayRef<mlir::clift::FieldAttr>`");
+                       "`llvm::ArrayRef<mlir::clift::FieldAttr>`");
     }
 
     if (Subobjects->size() < MinSubobjects) {

--- a/lib/mlir/Dialect/Clift/IR/CliftStorage.h
+++ b/lib/mlir/Dialect/Clift/IR/CliftStorage.h
@@ -142,17 +142,17 @@ struct StructTypeStorageValue {
   StructTypeStorageValue(const uint64_t Size) : Size(Size) {}
 };
 
-struct StructTypeStorage : ClassTypeStorage<StructTypeStorage,
-                                            mlir::AttributeStorage,
-                                            FieldAttr,
-                                            StructTypeStorageValue> {
+struct StructTypeAttrStorage : ClassTypeStorage<StructTypeAttrStorage,
+                                                mlir::AttributeStorage,
+                                                FieldAttr,
+                                                StructTypeStorageValue> {
   using ClassTypeStorage::ClassTypeStorage;
 
   [[nodiscard]] uint64_t getSize() const { return getValue().Size; }
 };
 
-struct UnionTypeStorage
-  : ClassTypeStorage<UnionTypeStorage, mlir::AttributeStorage, FieldAttr> {
+struct UnionTypeAttrStorage
+  : ClassTypeStorage<UnionTypeAttrStorage, mlir::AttributeStorage, FieldAttr> {
   using ClassTypeStorage::ClassTypeStorage;
 };
 

--- a/lib/mlir/Dialect/Clift/IR/CliftTypeHelpers.h
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypeHelpers.h
@@ -22,4 +22,69 @@ inline mlir::Type dealias(ValueType Type) {
   return Type;
 }
 
+inline bool isVoid(ValueType Type) {
+  Type = dealias(Type);
+
+  if (auto T = mlir::dyn_cast<PrimitiveType>(Type))
+    return T.getKind() == PrimitiveKind::VoidKind;
+
+  return false;
+}
+
+inline bool isCompleteType(ValueType Type) {
+  Type = dealias(Type);
+
+  if (auto T = mlir::dyn_cast<DefinedType>(Type)) {
+    auto Definition = T.getElementType();
+    if (auto D = mlir::dyn_cast<StructTypeAttr>(Definition))
+      return D.isDefinition();
+    if (auto D = mlir::dyn_cast<UnionTypeAttr>(Definition))
+      return D.isDefinition();
+    return true;
+  }
+
+  if (auto T = mlir::dyn_cast<ScalarTupleType>(Type))
+    return T.isComplete();
+
+  if (auto T = mlir::dyn_cast<ArrayType>(Type))
+    return isCompleteType(T.getElementType());
+
+  return true;
+}
+
+inline bool isScalarType(ValueType Type) {
+  Type = dealias(Type);
+
+  if (auto T = mlir::dyn_cast<PrimitiveType>(Type))
+    return T.getKind() != PrimitiveKind::VoidKind;
+
+  if (auto T = mlir::dyn_cast<DefinedType>(Type))
+    return mlir::isa<EnumTypeAttr>(T.getElementType());
+
+  return mlir::isa<PointerType>(Type);
+}
+
+inline bool isObjectType(ValueType Type) {
+  Type = dealias(Type);
+
+  if (auto T = mlir::dyn_cast<PrimitiveType>(Type)) {
+    if (T.getKind() == PrimitiveKind::VoidKind)
+      return false;
+  }
+
+  if (auto T = mlir::dyn_cast<DefinedType>(Type)) {
+    if (mlir::isa<FunctionTypeAttr>(T.getElementType()))
+      return false;
+  }
+
+  if (mlir::isa<ScalarTupleType>(Type))
+    return false;
+
+  return true;
+}
+
+inline bool isArrayType(ValueType Type) {
+  return mlir::isa<ArrayType>(dealias(Type));
+}
+
 } // namespace mlir::clift

--- a/lib/mlir/Dialect/Clift/IR/CliftTypeHelpers.h
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypeHelpers.h
@@ -1,0 +1,25 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "revng-c/mlir/Dialect/Clift/IR/CliftAttributes.h"
+#include "revng-c/mlir/Dialect/Clift/IR/CliftTypes.h"
+
+namespace mlir::clift {
+
+inline mlir::Type dealias(ValueType Type) {
+  const auto GetTypedefTypeAttr = [](ValueType Type) -> TypedefTypeAttr {
+    if (auto D = mlir::dyn_cast<DefinedType>(Type))
+      return mlir::dyn_cast<TypedefTypeAttr>(D.getElementType());
+    return nullptr;
+  };
+
+  while (auto Attr = GetTypedefTypeAttr(Type))
+    Type = Attr.getUnderlyingType();
+
+  return Type;
+}
+
+} // namespace mlir::clift

--- a/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
@@ -299,7 +299,7 @@ bool ScalarTupleType::isComplete() const {
 uint64_t ScalarTupleType::getByteSize() const {
   uint64_t Size = 0;
   for (ScalarTupleElementAttr Element : getElements())
-    Size += mlir::cast<ValueType>(Element.getType()).getByteSize();
+    Size += Element.getType().getByteSize();
   return Size;
 }
 

--- a/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
@@ -278,40 +278,38 @@ EnumAttr::verify(EmitErrorType emitError,
 
   return mlir::success();
 }
-void UnionType::walkImmediateSubElements(function_ref<void(Attribute)>
-                                           walkAttrsFn,
-                                         function_ref<void(Type)> walkTypesFn)
+
+void UnionTypeAttr::walkImmediateSubElements(function_ref<void(Attribute)>
+                                               WalkAttr,
+                                             function_ref<void(Type)> WalkType)
   const {
   if (not getImpl()->isInitialized())
     return;
   for (auto Field : getFields())
-    walkAttrsFn(Field);
+    WalkAttr(Field);
 }
 
 mlir::Attribute
-UnionType::replaceImmediateSubElements(llvm::ArrayRef<mlir::Attribute>
-                                         replAttrs,
-                                       llvm::ArrayRef<mlir::Type> replTypes)
-  const {
+UnionTypeAttr::replaceImmediateSubElements(llvm::ArrayRef<mlir::Attribute>,
+                                           llvm::ArrayRef<mlir::Type>) const {
   revng_abort("it does not make any sense to replace the elements of a "
-              "defined Union");
+              "defined union");
+  return {};
 }
 
-void StructType::walkImmediateSubElements(function_ref<void(Attribute)>
-                                            walkAttrsFn,
-                                          function_ref<void(Type)> walkTypesFn)
+void StructTypeAttr::walkImmediateSubElements(function_ref<void(Attribute)>
+                                                WalkAttr,
+                                              function_ref<void(Type)> WalkType)
   const {
   if (not getImpl()->isInitialized())
     return;
   for (auto Field : getFields())
-    walkAttrsFn(Field);
+    WalkAttr(Field);
 }
 
 mlir::Attribute
-StructType::replaceImmediateSubElements(llvm::ArrayRef<mlir::Attribute>
-                                          replAttrs,
-                                        llvm::ArrayRef<mlir::Type> replTypes)
-  const {
+StructTypeAttr::replaceImmediateSubElements(llvm::ArrayRef<mlir::Attribute>,
+                                            llvm::ArrayRef<mlir::Type>) const {
   revng_abort("it does not make any sense to replace the elements of a "
               "defined struct");
 }
@@ -450,9 +448,8 @@ void ScalarTupleType::walkImmediateSubElements(function_ref<void(Attribute)>
   }
 }
 
-mlir::Type
-ScalarTupleType::replaceImmediateSubElements(ArrayRef<Attribute> NewAttrs,
-                                             ArrayRef<Type> NewTypes) const {
+mlir::Type ScalarTupleType::replaceImmediateSubElements(ArrayRef<Attribute>,
+                                                        ArrayRef<Type>) const {
   revng_abort("it does not make any sense to replace the elements of a "
               "scalar tuple");
 }

--- a/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
@@ -89,7 +89,7 @@ mlir::clift::PrimitiveType::verify(EmitErrorType EmitError,
   return mlir::success();
 }
 
-std::string mlir::clift::EnumAttr::getAlias() const {
+std::string mlir::clift::EnumTypeAttr::getAlias() const {
   return getName().str();
 }
 
@@ -108,11 +108,11 @@ std::string mlir::clift::PrimitiveType::getAlias() const {
                      serializeToString(Type.name());
 }
 
-std::string mlir::clift::TypedefAttr::getAlias() const {
+std::string mlir::clift::TypedefTypeAttr::getAlias() const {
   return getName().str();
 }
 
-std::string mlir::clift::FunctionAttr::getAlias() const {
+std::string mlir::clift::FunctionTypeAttr::getAlias() const {
   return getName().str();
 }
 
@@ -132,7 +132,7 @@ uint64_t mlir::clift::DefinedType::getByteSize() const {
   return getElementType().cast<mlir::clift::SizedType>().getByteSize();
 }
 
-uint64_t mlir::clift::EnumAttr::getByteSize() const {
+uint64_t mlir::clift::EnumTypeAttr::getByteSize() const {
   return getUnderlyingType().cast<mlir::clift::PrimitiveType>().getSize();
 }
 
@@ -140,11 +140,11 @@ uint64_t mlir::clift::PointerType::getByteSize() const {
   return getPointerSize();
 }
 
-uint64_t mlir::clift::TypedefAttr::getByteSize() const {
+uint64_t mlir::clift::TypedefTypeAttr::getByteSize() const {
   return getUnderlyingType().getByteSize();
 }
 
-uint64_t mlir::clift::FunctionAttr::getByteSize() const {
+uint64_t mlir::clift::FunctionTypeAttr::getByteSize() const {
   return 0;
 }
 
@@ -164,7 +164,7 @@ mlir::LogicalResult PointerType::verify(EmitErrorType emitError,
 
 mlir::LogicalResult
 DefinedType::verify(EmitErrorType emitError,
-                    mlir::clift::TypeDefinition element_type,
+                    mlir::clift::TypeDefinitionAttr element_type,
                     BoolAttr IsConst) {
   return mlir::success();
 }
@@ -184,9 +184,9 @@ mlir::LogicalResult ArrayType::verify(EmitErrorType emitError,
   return mlir::success();
 }
 
-static mlir::clift::TypedefAttr getTypedefAttr(mlir::Type Type) {
+static mlir::clift::TypedefTypeAttr getTypedefAttr(mlir::Type Type) {
   if (auto D = mlir::dyn_cast<mlir::clift::DefinedType>(Type))
-    return mlir::dyn_cast<mlir::clift::TypedefAttr>(D.getElementType());
+    return mlir::dyn_cast<mlir::clift::TypedefTypeAttr>(D.getElementType());
   return nullptr;
 }
 
@@ -198,11 +198,11 @@ static mlir::Type dealias(mlir::Type Type) {
 
 using namespace mlir::clift;
 mlir::LogicalResult
-EnumAttr::verify(EmitErrorType emitError,
-                 uint64_t ID,
-                 llvm::StringRef,
-                 mlir::Type UnderlyingType,
-                 llvm::ArrayRef<mlir::clift::EnumFieldAttr> Fields) {
+EnumTypeAttr::verify(EmitErrorType emitError,
+                     uint64_t ID,
+                     llvm::StringRef,
+                     mlir::Type UnderlyingType,
+                     llvm::ArrayRef<mlir::clift::EnumFieldAttr> Fields) {
   UnderlyingType = dealias(UnderlyingType);
 
   if (not UnderlyingType.isa<mlir::clift::PrimitiveType>())
@@ -323,7 +323,7 @@ static bool isScalarType(mlir::Type Type) {
     return T.getKind() != PrimitiveKind::VoidKind;
 
   if (auto T = mlir::dyn_cast<DefinedType>(Type))
-    return mlir::isa<EnumAttr>(T.getElementType());
+    return mlir::isa<EnumTypeAttr>(T.getElementType());
 
   return mlir::isa<PointerType>(Type);
 }

--- a/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
@@ -18,11 +18,13 @@
 #define GET_TYPEDEF_CLASSES
 #include "revng-c/mlir/Dialect/Clift/IR/CliftOpsTypes.cpp.inc"
 
+using namespace mlir::clift;
+
 using EmitErrorType = llvm::function_ref<mlir::InFlightDiagnostic()>;
 
 //******************************** CliftDialect ********************************
 
-void mlir::clift::CliftDialect::registerTypes() {
+void CliftDialect::registerTypes() {
   addTypes<ScalarTupleType, /* Include the auto-generated clift types */
 #define GET_TYPEDEF_LIST
 #include "revng-c/mlir/Dialect/Clift/IR/CliftOpsTypes.cpp.inc"
@@ -30,8 +32,7 @@ void mlir::clift::CliftDialect::registerTypes() {
 }
 
 /// Parse a type registered to this dialect
-mlir::Type
-mlir::clift::CliftDialect::parseType(mlir::DialectAsmParser &Parser) const {
+mlir::Type CliftDialect::parseType(mlir::DialectAsmParser &Parser) const {
   const llvm::SMLoc TypeLoc = Parser.getCurrentLocation();
 
   llvm::StringRef Mnemonic;
@@ -48,9 +49,8 @@ mlir::clift::CliftDialect::parseType(mlir::DialectAsmParser &Parser) const {
 }
 
 /// Print a type registered to this dialect
-void mlir::clift::CliftDialect::printType(mlir::Type Type,
-                                          mlir::DialectAsmPrinter &Printer)
-  const {
+void CliftDialect::printType(mlir::Type Type,
+                             mlir::DialectAsmPrinter &Printer) const {
 
   if (mlir::succeeded(generatedTypePrinter(Type, Printer)))
     return;
@@ -60,12 +60,11 @@ void mlir::clift::CliftDialect::printType(mlir::Type Type,
 }
 
 static constexpr model::PrimitiveType::PrimitiveKindType
-kindToKind(mlir::clift::PrimitiveKind kind) {
+kindToKind(PrimitiveKind kind) {
   return static_cast<model::PrimitiveType::PrimitiveKindType>(kind);
 }
 
 using Primitive = model::PrimitiveType::PrimitiveKindType;
-using namespace mlir::clift;
 static_assert(Primitive::Float == kindToKind(PrimitiveKind::FloatKind));
 static_assert(Primitive::Void == kindToKind(PrimitiveKind::VoidKind));
 static const auto
@@ -76,11 +75,10 @@ static_assert(Primitive::Generic == kindToKind(PrimitiveKind::GenericKind));
 static_assert(Primitive::Signed == kindToKind(PrimitiveKind::SignedKind));
 static_assert(Primitive::Number == kindToKind(PrimitiveKind::NumberKind));
 
-mlir::LogicalResult
-mlir::clift::PrimitiveType::verify(EmitErrorType EmitError,
-                                   mlir::clift::PrimitiveKind kind,
-                                   uint64_t size,
-                                   BoolAttr IsConst) {
+mlir::LogicalResult PrimitiveType::verify(EmitErrorType EmitError,
+                                          PrimitiveKind kind,
+                                          uint64_t size,
+                                          BoolAttr IsConst) {
 
   model::PrimitiveType Type(kindToKind(kind), size);
   if (not Type.verify()) {
@@ -89,12 +87,12 @@ mlir::clift::PrimitiveType::verify(EmitErrorType EmitError,
   return mlir::success();
 }
 
-std::string mlir::clift::EnumTypeAttr::getAlias() const {
+std::string EnumTypeAttr::getAlias() const {
   return getName().str();
 }
 
-std::string mlir::clift::DefinedType::getAlias() const {
-  if (auto Casted = getElementType().dyn_cast<mlir::clift::AliasableAttr>()) {
+std::string DefinedType::getAlias() const {
+  if (auto Casted = getElementType().dyn_cast<AliasableAttr>()) {
     if (Casted.getAlias().empty())
       return "";
     return isConst() ? "const_" + Casted.getAlias() : Casted.getAlias();
@@ -102,54 +100,54 @@ std::string mlir::clift::DefinedType::getAlias() const {
   return "";
 }
 
-std::string mlir::clift::PrimitiveType::getAlias() const {
+std::string PrimitiveType::getAlias() const {
   model::PrimitiveType Type(kindToKind(getKind()), getByteSize());
   return isConst() ? std::string("const_") + serializeToString(Type.name()) :
                      serializeToString(Type.name());
 }
 
-std::string mlir::clift::TypedefTypeAttr::getAlias() const {
+std::string TypedefTypeAttr::getAlias() const {
   return getName().str();
 }
 
-std::string mlir::clift::FunctionTypeAttr::getAlias() const {
+std::string FunctionTypeAttr::getAlias() const {
   return getName().str();
 }
 
-llvm::StringRef mlir::clift::DefinedType::name() {
+llvm::StringRef DefinedType::name() {
   return getElementType().name();
 }
 
-uint64_t mlir::clift::DefinedType::id() {
+uint64_t DefinedType::id() {
   return getElementType().id();
 }
 
-uint64_t mlir::clift::ArrayType::getByteSize() const {
+uint64_t ArrayType::getByteSize() const {
   return getElementType().getByteSize() * getElementsCount();
 }
 
-uint64_t mlir::clift::DefinedType::getByteSize() const {
-  return getElementType().cast<mlir::clift::SizedType>().getByteSize();
+uint64_t DefinedType::getByteSize() const {
+  return getElementType().cast<SizedType>().getByteSize();
 }
 
-uint64_t mlir::clift::EnumTypeAttr::getByteSize() const {
-  return getUnderlyingType().cast<mlir::clift::PrimitiveType>().getSize();
+uint64_t EnumTypeAttr::getByteSize() const {
+  return getUnderlyingType().cast<PrimitiveType>().getSize();
 }
 
-uint64_t mlir::clift::PointerType::getByteSize() const {
+uint64_t PointerType::getByteSize() const {
   return getPointerSize();
 }
 
-uint64_t mlir::clift::TypedefTypeAttr::getByteSize() const {
+uint64_t TypedefTypeAttr::getByteSize() const {
   return getUnderlyingType().getByteSize();
 }
 
-uint64_t mlir::clift::FunctionTypeAttr::getByteSize() const {
+uint64_t FunctionTypeAttr::getByteSize() const {
   return 0;
 }
 
 mlir::LogicalResult PointerType::verify(EmitErrorType emitError,
-                                        mlir::clift::ValueType element_type,
+                                        clift::ValueType element_type,
                                         uint64_t pointer_size,
                                         BoolAttr IsConst) {
   switch (pointer_size) {
@@ -162,15 +160,14 @@ mlir::LogicalResult PointerType::verify(EmitErrorType emitError,
   return mlir::success();
 }
 
-mlir::LogicalResult
-DefinedType::verify(EmitErrorType emitError,
-                    mlir::clift::TypeDefinitionAttr element_type,
-                    BoolAttr IsConst) {
+mlir::LogicalResult DefinedType::verify(EmitErrorType emitError,
+                                        TypeDefinitionAttr element_type,
+                                        BoolAttr IsConst) {
   return mlir::success();
 }
 
 mlir::LogicalResult ArrayType::verify(EmitErrorType emitError,
-                                      mlir::clift::ValueType element_type,
+                                      clift::ValueType element_type,
                                       uint64_t count,
                                       BoolAttr IsConst) {
   if (count == 0) {
@@ -184,9 +181,9 @@ mlir::LogicalResult ArrayType::verify(EmitErrorType emitError,
   return mlir::success();
 }
 
-static mlir::clift::TypedefTypeAttr getTypedefAttr(mlir::Type Type) {
-  if (auto D = mlir::dyn_cast<mlir::clift::DefinedType>(Type))
-    return mlir::dyn_cast<mlir::clift::TypedefTypeAttr>(D.getElementType());
+static TypedefTypeAttr getTypedefAttr(mlir::Type Type) {
+  if (auto D = mlir::dyn_cast<DefinedType>(Type))
+    return mlir::dyn_cast<TypedefTypeAttr>(D.getElementType());
   return nullptr;
 }
 
@@ -196,19 +193,17 @@ static mlir::Type dealias(mlir::Type Type) {
   return Type;
 }
 
-using namespace mlir::clift;
-mlir::LogicalResult
-EnumTypeAttr::verify(EmitErrorType emitError,
-                     uint64_t ID,
-                     llvm::StringRef,
-                     mlir::Type UnderlyingType,
-                     llvm::ArrayRef<mlir::clift::EnumFieldAttr> Fields) {
+mlir::LogicalResult EnumTypeAttr::verify(EmitErrorType emitError,
+                                         uint64_t ID,
+                                         llvm::StringRef,
+                                         mlir::Type UnderlyingType,
+                                         llvm::ArrayRef<EnumFieldAttr> Fields) {
   UnderlyingType = dealias(UnderlyingType);
 
-  if (not UnderlyingType.isa<mlir::clift::PrimitiveType>())
+  if (not UnderlyingType.isa<PrimitiveType>())
     return emitError() << "type of enum must be a primitive type";
 
-  const auto PrimitiveType = UnderlyingType.cast<mlir::clift::PrimitiveType>();
+  const auto PrimitiveType = UnderlyingType.cast<clift::PrimitiveType>();
   const uint64_t BitWidth = PrimitiveType.getSize() * 8;
 
   if (Fields.empty())

--- a/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
@@ -44,7 +44,7 @@ mlir::Type CliftDialect::parseType(mlir::DialectAsmParser &Parser) const {
   if (Mnemonic == ScalarTupleType::getMnemonic())
     return ScalarTupleType::parse(Parser);
 
-  Parser.emitError(TypeLoc) << "unknown  type `" << Mnemonic << "` in dialect `"
+  Parser.emitError(TypeLoc) << "unknown type `" << Mnemonic << "` in dialect `"
                             << getNamespace() << "`";
   return {};
 }
@@ -109,10 +109,10 @@ static consteval bool testKindToKind() {
 static_assert(testKindToKind());
 
 mlir::LogicalResult PrimitiveType::verify(EmitErrorType EmitError,
-                                          PrimitiveKind kind,
-                                          uint64_t size,
+                                          PrimitiveKind Kind,
+                                          uint64_t Size,
                                           BoolAttr IsConst) {
-  model::PrimitiveType Type(kindToKind(kind), size);
+  model::PrimitiveType Type(kindToKind(Kind), Size);
   if (not Type.verify()) {
     return EmitError() << "primitive type verify failed";
   }
@@ -127,16 +127,16 @@ std::string PrimitiveType::getAlias() const {
 
 //===----------------------------- PointerType ----------------------------===//
 
-mlir::LogicalResult PointerType::verify(EmitErrorType emitError,
-                                        ValueType element_type,
-                                        uint64_t pointer_size,
+mlir::LogicalResult PointerType::verify(EmitErrorType EmitError,
+                                        ValueType ElementType,
+                                        uint64_t PointerSize,
                                         BoolAttr IsConst) {
-  switch (pointer_size) {
+  switch (PointerSize) {
   case 4:
   case 8:
     break;
   default:
-    return emitError() << "invalid pointer size: " << pointer_size;
+    return EmitError() << "invalid pointer size: " << PointerSize;
   }
   return mlir::success();
 }
@@ -147,15 +147,15 @@ uint64_t PointerType::getByteSize() const {
 
 //===------------------------------ ArrayType -----------------------------===//
 
-mlir::LogicalResult ArrayType::verify(EmitErrorType emitError,
-                                      ValueType element_type,
-                                      uint64_t count,
+mlir::LogicalResult ArrayType::verify(EmitErrorType EmitError,
+                                      ValueType ElementType,
+                                      uint64_t ElementCount,
                                       BoolAttr IsConst) {
-  if (count == 0) {
-    return emitError() << "array type cannot have zero elements";
+  if (ElementCount == 0) {
+    return EmitError() << "array type cannot have zero elements";
   }
-  if (element_type.getByteSize() == 0) {
-    return emitError() << "array type cannot have size zero. Did you created a "
+  if (ElementType.getByteSize() == 0) {
+    return EmitError() << "array type cannot have size zero. Did you created a "
                           "array type with a uninitialized struct or union "
                           "type inside?";
   }
@@ -168,8 +168,8 @@ uint64_t ArrayType::getByteSize() const {
 
 //===----------------------------- DefinedType ----------------------------===//
 
-mlir::LogicalResult DefinedType::verify(EmitErrorType emitError,
-                                        TypeDefinitionAttr element_type,
+mlir::LogicalResult DefinedType::verify(EmitErrorType EmitError,
+                                        TypeDefinitionAttr Definition,
                                         BoolAttr IsConst) {
   return mlir::success();
 }
@@ -183,7 +183,7 @@ llvm::StringRef DefinedType::name() {
 }
 
 uint64_t DefinedType::getByteSize() const {
-  return getElementType().cast<SizedType>().getByteSize();
+  return mlir::cast<SizedType>(getElementType()).getByteSize();
 }
 
 std::string DefinedType::getAlias() const {

--- a/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
@@ -48,11 +48,11 @@ mlir::clift::CliftDialect::parseType(mlir::DialectAsmParser &Parser) const {
 }
 
 /// Print a type registered to this dialect
-void mlir::clift::CliftDialect::printType(::mlir::Type Type,
-                                          ::mlir::DialectAsmPrinter &Printer)
+void mlir::clift::CliftDialect::printType(mlir::Type Type,
+                                          mlir::DialectAsmPrinter &Printer)
   const {
 
-  if (::mlir::succeeded(generatedTypePrinter(Type, Printer)))
+  if (mlir::succeeded(generatedTypePrinter(Type, Printer)))
     return;
 
   if (auto T = mlir::dyn_cast<ScalarTupleType>(Type))
@@ -148,10 +148,10 @@ uint64_t mlir::clift::FunctionAttr::getByteSize() const {
   return 0;
 }
 
-::mlir::LogicalResult PointerType::verify(EmitErrorType emitError,
-                                          mlir::clift::ValueType element_type,
-                                          uint64_t pointer_size,
-                                          BoolAttr IsConst) {
+mlir::LogicalResult PointerType::verify(EmitErrorType emitError,
+                                        mlir::clift::ValueType element_type,
+                                        uint64_t pointer_size,
+                                        BoolAttr IsConst) {
   switch (pointer_size) {
   case 4:
   case 8:
@@ -162,17 +162,17 @@ uint64_t mlir::clift::FunctionAttr::getByteSize() const {
   return mlir::success();
 }
 
-::mlir::LogicalResult
+mlir::LogicalResult
 DefinedType::verify(EmitErrorType emitError,
                     mlir::clift::TypeDefinition element_type,
                     BoolAttr IsConst) {
   return mlir::success();
 }
 
-::mlir::LogicalResult ArrayType::verify(EmitErrorType emitError,
-                                        mlir::clift::ValueType element_type,
-                                        uint64_t count,
-                                        BoolAttr IsConst) {
+mlir::LogicalResult ArrayType::verify(EmitErrorType emitError,
+                                      mlir::clift::ValueType element_type,
+                                      uint64_t count,
+                                      BoolAttr IsConst) {
   if (count == 0) {
     return emitError() << "array type cannot have zero elements";
   }
@@ -197,12 +197,12 @@ static mlir::Type dealias(mlir::Type Type) {
 }
 
 using namespace mlir::clift;
-::mlir::LogicalResult
+mlir::LogicalResult
 EnumAttr::verify(EmitErrorType emitError,
                  uint64_t ID,
-                 ::llvm::StringRef,
+                 llvm::StringRef,
                  mlir::Type UnderlyingType,
-                 ::llvm::ArrayRef<mlir::clift::EnumFieldAttr> Fields) {
+                 llvm::ArrayRef<mlir::clift::EnumFieldAttr> Fields) {
   UnderlyingType = dealias(UnderlyingType);
 
   if (not UnderlyingType.isa<mlir::clift::PrimitiveType>())

--- a/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
+++ b/lib/mlir/Dialect/Clift/IR/CliftTypes.cpp
@@ -54,9 +54,11 @@ void CliftDialect::printType(mlir::Type Type,
                              mlir::DialectAsmPrinter &Printer) const {
   if (mlir::succeeded(generatedTypePrinter(Type, Printer)))
     return;
-
-  if (auto T = mlir::dyn_cast<ScalarTupleType>(Type))
-    return T.print(Printer);
+  if (auto T = mlir::dyn_cast<ScalarTupleType>(Type)) {
+    T.print(Printer);
+    return;
+  }
+  revng_abort("cannot print type");
 }
 
 //===---------------------------- PrimitiveType ---------------------------===//

--- a/lib/mlir/Dialect/Clift/Utils/ImportModel.cpp
+++ b/lib/mlir/Dialect/Clift/Utils/ImportModel.cpp
@@ -307,7 +307,7 @@ private:
   getTypeAttribute(const model::StructType &ModelType,
                    const bool RequireComplete) {
     if (not RequireComplete) {
-      const auto T = clift::StructType::get(Context, ModelType.ID());
+      const auto T = clift::StructTypeAttr::get(Context, ModelType.ID());
       if (not T.isDefinition())
         IncompleteTypes.try_emplace(ModelType.ID(), &ModelType);
       rc_return T;
@@ -316,7 +316,8 @@ private:
     RecursiveDefinitionGuard Guard(*this, ModelType.ID());
     if (not Guard) {
       if (EmitError)
-        EmitError() << "Recursive definition of StructType " << ModelType.ID();
+        EmitError() << "Recursive definition of StructTypeAttr "
+                    << ModelType.ID();
       rc_return nullptr;
     }
 
@@ -336,10 +337,10 @@ private:
       Fields.push_back(Attribute);
     }
 
-    rc_return make<clift::StructType>(ModelType.ID(),
-                                      ModelType.name(),
-                                      ModelType.Size(),
-                                      Fields);
+    rc_return make<clift::StructTypeAttr>(ModelType.ID(),
+                                          ModelType.name(),
+                                          ModelType.Size(),
+                                          Fields);
   }
 
   RecursiveCoroutine<clift::TypeDefinition>
@@ -370,7 +371,7 @@ private:
   getTypeAttribute(const model::UnionType &ModelType,
                    const bool RequireComplete) {
     if (not RequireComplete) {
-      const auto T = clift::UnionType::get(Context, ModelType.ID());
+      const auto T = clift::UnionTypeAttr::get(Context, ModelType.ID());
       if (not T.isDefinition())
         IncompleteTypes.try_emplace(ModelType.ID(), &ModelType);
       rc_return T;
@@ -379,7 +380,8 @@ private:
     RecursiveDefinitionGuard Guard(*this, ModelType.ID());
     if (not Guard) {
       if (EmitError)
-        EmitError() << "Recursive definition of UnionType " << ModelType.ID();
+        EmitError() << "Recursive definition of UnionTypeAttr "
+                    << ModelType.ID();
       rc_return nullptr;
     }
 
@@ -397,7 +399,9 @@ private:
       Fields.push_back(Attribute);
     }
 
-    rc_return make<clift::UnionType>(ModelType.ID(), ModelType.name(), Fields);
+    rc_return make<clift::UnionTypeAttr>(ModelType.ID(),
+                                         ModelType.name(),
+                                         Fields);
   }
 
   RecursiveCoroutine<clift::TypeDefinition>

--- a/lib/mlir/Dialect/Clift/Utils/ImportModel.cpp
+++ b/lib/mlir/Dialect/Clift/Utils/ImportModel.cpp
@@ -23,7 +23,7 @@ class CliftConverter {
   mlir::MLIRContext *Context;
   llvm::function_ref<mlir::InFlightDiagnostic()> EmitError;
 
-  llvm::DenseMap<uint64_t, clift::TypeDefinition> Cache;
+  llvm::DenseMap<uint64_t, clift::TypeDefinitionAttr> Cache;
   llvm::DenseMap<uint64_t, const model::Type *> IncompleteTypes;
 
   llvm::SmallSet<uint64_t, 16> DefinitionGuardSet;
@@ -133,7 +133,7 @@ private:
                                       getBool(Const));
   }
 
-  RecursiveCoroutine<clift::TypeDefinition>
+  RecursiveCoroutine<clift::TypeDefinitionAttr>
   getTypeAttribute(const model::CABIFunctionType &ModelType) {
     RecursiveDefinitionGuard Guard(*this, ModelType.ID());
     if (not Guard) {
@@ -162,13 +162,13 @@ private:
     if (not ReturnType)
       rc_return nullptr;
 
-    rc_return make<clift::FunctionAttr>(ModelType.ID(),
-                                        ModelType.name(),
-                                        ReturnType,
-                                        Args);
+    rc_return make<clift::FunctionTypeAttr>(ModelType.ID(),
+                                            ModelType.name(),
+                                            ReturnType,
+                                            Args);
   }
 
-  RecursiveCoroutine<clift::TypeDefinition>
+  RecursiveCoroutine<clift::TypeDefinitionAttr>
   getTypeAttribute(const model::EnumType &ModelType) {
     RecursiveDefinitionGuard Guard(*this, ModelType.ID());
     if (not Guard) {
@@ -194,10 +194,10 @@ private:
       Fields.push_back(Attribute);
     }
 
-    rc_return make<clift::EnumAttr>(ModelType.ID(),
-                                    ModelType.name(),
-                                    UnderlyingType,
-                                    Fields);
+    rc_return make<clift::EnumTypeAttr>(ModelType.ID(),
+                                        ModelType.name(),
+                                        UnderlyingType,
+                                        Fields);
   }
 
   RecursiveCoroutine<clift::ValueType>
@@ -222,7 +222,7 @@ private:
     rc_return make<clift::ScalarTupleType>(ModelType.ID(), "", Elements);
   }
 
-  RecursiveCoroutine<clift::TypeDefinition>
+  RecursiveCoroutine<clift::TypeDefinitionAttr>
   getTypeAttribute(const model::RawFunctionType &ModelType) {
     RecursiveDefinitionGuard Guard(*this, ModelType.ID());
     if (not Guard) {
@@ -297,13 +297,13 @@ private:
     if (not ReturnType)
       rc_return nullptr;
 
-    rc_return make<clift::FunctionAttr>(ModelType.ID(),
-                                        ModelType.name(),
-                                        ReturnType,
-                                        Args);
+    rc_return make<clift::FunctionTypeAttr>(ModelType.ID(),
+                                            ModelType.name(),
+                                            ReturnType,
+                                            Args);
   }
 
-  RecursiveCoroutine<clift::TypeDefinition>
+  RecursiveCoroutine<clift::TypeDefinitionAttr>
   getTypeAttribute(const model::StructType &ModelType,
                    const bool RequireComplete) {
     if (not RequireComplete) {
@@ -343,7 +343,7 @@ private:
                                           Fields);
   }
 
-  RecursiveCoroutine<clift::TypeDefinition>
+  RecursiveCoroutine<clift::TypeDefinitionAttr>
   getTypeAttribute(const model::TypedefType &ModelType,
                    const bool RequireComplete) {
     std::optional<RecursiveDefinitionGuard> Guard;
@@ -362,12 +362,12 @@ private:
       getQualifiedValueType(ModelType.UnderlyingType(), RequireComplete);
     if (not UnderlyingType)
       rc_return nullptr;
-    rc_return make<clift::TypedefAttr>(ModelType.ID(),
-                                       ModelType.name(),
-                                       UnderlyingType);
+    rc_return make<clift::TypedefTypeAttr>(ModelType.ID(),
+                                           ModelType.name(),
+                                           UnderlyingType);
   }
 
-  RecursiveCoroutine<clift::TypeDefinition>
+  RecursiveCoroutine<clift::TypeDefinitionAttr>
   getTypeAttribute(const model::UnionType &ModelType,
                    const bool RequireComplete) {
     if (not RequireComplete) {
@@ -404,7 +404,7 @@ private:
                                          Fields);
   }
 
-  RecursiveCoroutine<clift::TypeDefinition>
+  RecursiveCoroutine<clift::TypeDefinitionAttr>
   getTypeAttribute(const model::Type &ModelType, bool &RequireComplete) {
     switch (ModelType.Kind()) {
     case model::TypeKind::CABIFunctionType: {
@@ -458,8 +458,8 @@ private:
     if (const auto It = Cache.find(ModelType.ID()); It != Cache.end())
       rc_return getDefinedType(It->second);
 
-    const clift::TypeDefinition Attr = getTypeAttribute(ModelType,
-                                                        RequireComplete);
+    const clift::TypeDefinitionAttr Attr = getTypeAttribute(ModelType,
+                                                            RequireComplete);
 
     if (not Attr)
       rc_return nullptr;

--- a/lib/mlir/Dialect/Clift/Utils/ImportModel.cpp
+++ b/lib/mlir/Dialect/Clift/Utils/ImportModel.cpp
@@ -63,28 +63,21 @@ public:
   CliftConverter(const CliftConverter &) = delete;
   CliftConverter &operator=(const CliftConverter &) = delete;
 
-  ~CliftConverter() {
-    revng_assert(DefinitionGuardSet.empty());
-    revng_assert(IncompleteTypes.empty());
-  }
+  ~CliftConverter() { revng_assert(DefinitionGuardSet.empty()); }
 
   clift::ValueType convertUnqualifiedType(const model::Type &ModelType) {
     const clift::ValueType T = getUnwrappedValueType(ModelType,
                                                      /*RequireComplete=*/true);
-    if (T and not processIncompleteTypes()) {
-      IncompleteTypes.clear();
+    if (T and not processIncompleteTypes())
       return nullptr;
-    }
     return T;
   }
 
   clift::ValueType convertQualifiedType(const model::QualifiedType &ModelType) {
     const clift::ValueType T = getQualifiedValueType(ModelType,
                                                      /*RequireComplete=*/true);
-    if (T and not processIncompleteTypes()) {
-      IncompleteTypes.clear();
+    if (T and not processIncompleteTypes())
       return nullptr;
-    }
     return T;
   }
 

--- a/tests/unit/Clift.cpp
+++ b/tests/unit/Clift.cpp
@@ -125,13 +125,12 @@ BOOST_AUTO_TEST_CASE(UnionAndStructsCantContainThemself) {
 
 BOOST_AUTO_TEST_CASE(UnionAndStructsCantContainFunctions) {
   auto VoidT = PrimitiveType::getVoid(builder.getContext(), 0);
-  auto FunctionT = FunctionTypeAttr::get(0, VoidT);
-  auto UnionT = DefinedType::get(builder.getContext(),
-                                 FunctionT,
-                                 mlir::BoolAttr::get(builder.getContext(),
-                                                     false));
+  auto FunctionT = DefinedType::get(builder.getContext(),
+                                    FunctionTypeAttr::get(0, VoidT),
+                                    mlir::BoolAttr::get(builder.getContext(),
+                                                        false));
 
-  BOOST_TEST(FieldAttr::verify(getDiagnosticEmitter(), 0, UnionT, "field")
+  BOOST_TEST(FieldAttr::verify(getDiagnosticEmitter(), 0, FunctionT, "field")
                .failed());
 }
 

--- a/tests/unit/Clift.cpp
+++ b/tests/unit/Clift.cpp
@@ -70,10 +70,12 @@ BOOST_AUTO_TEST_CASE(CliftModuleCannotContaintTypesWithSameID) {
   builder.createBlock(&cliftModule.getBody());
   auto TrueAttr = mlir::BoolAttr::get(&context, true);
   auto T1 = mlir::TypeAttr::get(DefinedType::get(&context,
-                                                 StructType::get(&context, 1),
+                                                 StructTypeAttr::get(&context,
+                                                                     1),
                                                  TrueAttr));
   auto T2 = mlir::TypeAttr::get(DefinedType::get(&context,
-                                                 UnionType::get(&context, 1),
+                                                 UnionTypeAttr::get(&context,
+                                                                    1),
                                                  TrueAttr));
   cliftModule->setAttr("dc", T1);
   cliftModule->setAttr("dc2", T2);
@@ -112,7 +114,7 @@ BOOST_AUTO_TEST_CASE(LabelsWithAGoToWithoutAssignMustFail) {
 }
 
 BOOST_AUTO_TEST_CASE(UnionAndStructsCantContainThemself) {
-  auto UnionAttrT = mlir::clift::UnionType::get(builder.getContext(), 0);
+  auto UnionAttrT = mlir::clift::UnionTypeAttr::get(builder.getContext(), 0);
   using DefinedT = mlir::clift::DefinedType;
   auto UnionT = DefinedT::get(builder.getContext(),
                               UnionAttrT,

--- a/tests/unit/Clift.cpp
+++ b/tests/unit/Clift.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(UnionAndStructsCantContainThemself) {
 BOOST_AUTO_TEST_CASE(UnionAndStructsCantContainFunctions) {
   using namespace mlir::clift;
   auto VoidT = PrimitiveType::getVoid(builder.getContext(), 0);
-  auto FunctionT = FunctionAttr::get(0, VoidT);
+  auto FunctionT = FunctionTypeAttr::get(0, VoidT);
   auto UnionT = DefinedType::get(builder.getContext(),
                                  FunctionT,
                                  mlir::BoolAttr::get(builder.getContext(),
@@ -156,10 +156,10 @@ BOOST_AUTO_TEST_CASE(FunctionTypesCantContainVoidArgs) {
 
 BOOST_AUTO_TEST_CASE(FunctionTypesCantContainFunctionTypes) {
   using namespace mlir::clift;
-  auto FunctionT = FunctionAttr::get(0,
-                                     PrimitiveType::getVoid(builder
-                                                              .getContext(),
-                                                            0));
+  auto FunctionT = FunctionTypeAttr::get(0,
+                                         PrimitiveType::getVoid(builder
+                                                                  .getContext(),
+                                                                0));
 
   using DefinedT = mlir::clift::DefinedType;
   auto DefinedType = DefinedT::get(builder.getContext(),
@@ -167,11 +167,11 @@ BOOST_AUTO_TEST_CASE(FunctionTypesCantContainFunctionTypes) {
                                    mlir::BoolAttr::get(builder.getContext(),
                                                        false));
 
-  BOOST_TEST(mlir::clift::FunctionAttr::verify(getDiagnosticEmitter(),
-                                               1,
-                                               "",
-                                               DefinedType,
-                                               {})
+  BOOST_TEST(mlir::clift::FunctionTypeAttr::verify(getDiagnosticEmitter(),
+                                                   1,
+                                                   "",
+                                                   DefinedType,
+                                                   {})
                .failed());
 }
 

--- a/tests/unit/mlir_lit_tests/model-import/ArrayType.yml
+++ b/tests/unit/mlir_lit_tests/model-import/ArrayType.yml
@@ -9,7 +9,7 @@ Types:
     PrimitiveKind: Generic
     Size: 1
 
-    # CHECK: #my_struct = #clift.struct<
+    # CHECK: #my_struct$def = #clift.struct<
     # CHECK:   id = 1001
     # CHECK:   name = "my_struct"
     # CHECK:   size = 1024
@@ -23,7 +23,7 @@ Types:
     # CHECK:     >
     # CHECK:   ]
     # CHECK: >
-    # CHECK: !my_struct1 = !clift.defined<#my_struct>
+    # CHECK: !my_struct = !clift.defined<#my_struct$def>
   - ID: 1001
     Kind: StructType
     CustomName: "my_struct"

--- a/tests/unit/mlir_lit_tests/model-import/CABIFunctionType.yml
+++ b/tests/unit/mlir_lit_tests/model-import/CABIFunctionType.yml
@@ -22,13 +22,13 @@ Types:
     PrimitiveKind: Unsigned
     Size: 4
 
-    # CHECK: #my_function1_ = #clift.function<
+    # CHECK: #my_function1$def = #clift.function<
     # CHECK:   id = 1001
     # CHECK:   name = "my_function1"
     # CHECK:   return_type = !void
     # CHECK:   argument_types = []
     # CHECK: >
-    # CHECK: !my_function1_1 = !clift.defined<#my_function1_>
+    # CHECK: !my_function1_ = !clift.defined<#my_function1$def>
   - ID: 1001
     Kind: CABIFunctionType
     CustomName: "my_function1"
@@ -37,7 +37,7 @@ Types:
       UnqualifiedType: "/Types/100-PrimitiveType"
     Arguments: []
 
-    # CHECK: #my_function2_ = #clift.function<
+    # CHECK: #my_function2$def = #clift.function<
     # CHECK:   id = 1002
     # CHECK:   name = "my_function2"
     # CHECK:   return_type = !uint8_t
@@ -50,7 +50,7 @@ Types:
     # CHECK:     >
     # CHECK:   ]
     # CHECK: >
-    # CHECK: !my_function2_1 = !clift.defined<#my_function2_>
+    # CHECK: !my_function2_ = !clift.defined<#my_function2$def>
   - ID: 1002
     Kind: CABIFunctionType
     CustomName: "my_function2"

--- a/tests/unit/mlir_lit_tests/model-import/EnumType.yml
+++ b/tests/unit/mlir_lit_tests/model-import/EnumType.yml
@@ -26,7 +26,7 @@ Types:
     PrimitiveKind: Unsigned
     Size: 8
 
-    # CHECK: #my_enum1_ = #clift.enum<
+    # CHECK: #my_enum1$def = #clift.enum<
     # CHECK:   id = 1104
     # CHECK:   name = "my_enum1"
     # CHECK:   underlying_type = !int32_t
@@ -60,7 +60,7 @@ Types:
       - Value: 0xffffffff80000000 # 2^64 - 2^31
       - Value: 0xffffffffffffffff # 2^64 - 1
 
-    # CHECK: #my_enum2_ = #clift.enum<
+    # CHECK: #my_enum2$def = #clift.enum<
     # CHECK:   id = 1108
     # CHECK:   name = "my_enum2"
     # CHECK:   underlying_type = !int64_t
@@ -94,7 +94,7 @@ Types:
       - Value: 0x8000000000000000 # 2^63
       - Value: 0xffffffffffffffff # 2^64 - 1
 
-    # CHECK: #my_enum3_ = #clift.enum<
+    # CHECK: #my_enum3$def = #clift.enum<
     # CHECK:   id = 1204
     # CHECK:   name = "my_enum3"
     # CHECK:   underlying_type = !uint32_t
@@ -120,7 +120,7 @@ Types:
       - Value: 1
       - Value: 0x00000000ffffffff # 2^32 - 1
 
-    # CHECK: #my_enum4_ = #clift.enum<
+    # CHECK: #my_enum4$def = #clift.enum<
     # CHECK:   id = 1208
     # CHECK:   name = "my_enum4"
     # CHECK:   underlying_type = !uint64_t
@@ -147,7 +147,7 @@ Types:
       - Value: 0xffffffffffffffff # 2^64 - 1
 
 
-    # CHECK: !my_enum1_1 = !clift.defined<#my_enum1_>
-    # CHECK: !my_enum2_1 = !clift.defined<#my_enum2_>
-    # CHECK: !my_enum3_1 = !clift.defined<#my_enum3_>
-    # CHECK: !my_enum4_1 = !clift.defined<#my_enum4_>
+    # CHECK: !my_enum1_ = !clift.defined<#my_enum1$def>
+    # CHECK: !my_enum2_ = !clift.defined<#my_enum2$def>
+    # CHECK: !my_enum3_ = !clift.defined<#my_enum3$def>
+    # CHECK: !my_enum4_ = !clift.defined<#my_enum4$def>

--- a/tests/unit/mlir_lit_tests/model-import/RawFunctionType.yml
+++ b/tests/unit/mlir_lit_tests/model-import/RawFunctionType.yml
@@ -18,13 +18,13 @@ Types:
         Type:
           UnqualifiedType: "/Types/108-PrimitiveType"
 
-    # CHECK: #my_function1_ = #clift.function<
+    # CHECK: #my_function1$def = #clift.function<
     # CHECK:   id = 1000
     # CHECK:   name = "my_function1"
     # CHECK:   return_type = !void
     # CHECK:   argument_types = []
     # CHECK: >
-    # CHECK: !my_function1_1 = !clift.defined<#my_function1_>
+    # CHECK: !my_function1_ = !clift.defined<#my_function1$def>
   - ID: 1000
     Kind: RawFunctionType
     CustomName: "my_function1"
@@ -34,7 +34,7 @@ Types:
     PreservedRegisters: []
     FinalStackOffset: 0
 
-    # CHECK: #my_function2_ = #clift.function<
+    # CHECK: #my_function2$def = #clift.function<
     # CHECK:   id = 1001
     # CHECK:   name = "my_function2"
     # CHECK:   return_type = !uint64_t
@@ -42,7 +42,7 @@ Types:
     # CHECK:     !uint64_t
     # CHECK:   ]
     # CHECK: >
-    # CHECK: !my_function2_1 = !clift.defined<#my_function2_>
+    # CHECK: !my_function2_ = !clift.defined<#my_function2$def>
   - ID: 1001
     Kind: RawFunctionType
     CustomName: "my_function2"
@@ -59,7 +59,7 @@ Types:
       - rdi_x86_64
     FinalStackOffset: 0
 
-    # CHECK: #my_function3_ = #clift.function<
+    # CHECK: #my_function3$def = #clift.function<
     # CHECK:   id = 1002
     # CHECK:   name = "my_function3"
     # CHECK:   return_type = !clift.tuple<
@@ -69,10 +69,7 @@ Types:
     # CHECK:         type = !uint64_t
     # CHECK:       >
     # CHECK:       <
-    # CHECK:         type = !clift.pointer<
-    # CHECK:           pointee_type = !uint64_t
-    # CHECK:           pointer_size = 8
-    # CHECK:         >
+    # CHECK:         type = !clift.pointer<pointee_type = !uint64_t, pointer_size = 8>
     # CHECK:       >
     # CHECK:     ]
     # CHECK:   >
@@ -81,20 +78,14 @@ Types:
     # CHECK:       type = !uint64_t
     # CHECK:     >
     # CHECK:     <
-    # CHECK:       type = !clift.pointer<
-    # CHECK:         pointee_type = !uint64_t
-    # CHECK:         pointer_size = 8
-    # CHECK:       >
+    # CHECK:       type = !clift.pointer<pointee_type = !uint64_t, pointer_size = 8>
     # CHECK:     >
     # CHECK:     <
-    # CHECK:       type = !clift.pointer<
-    # CHECK:         pointee_type = !my_struct1
-    # CHECK:         pointer_size = 8
-    # CHECK:       >
+    # CHECK:       type = !clift.pointer<pointee_type = !my_struct, pointer_size = 8>
     # CHECK:     >
     # CHECK:   ]
     # CHECK: >
-    # CHECK: !my_function3_1 = !clift.defined<#my_function3_>
+    # CHECK: !my_function3_ = !clift.defined<#my_function3$def>
   - ID: 1002
     Kind: RawFunctionType
     CustomName: "my_function3"

--- a/tests/unit/mlir_lit_tests/model-import/RecursiveStructType.yml
+++ b/tests/unit/mlir_lit_tests/model-import/RecursiveStructType.yml
@@ -4,7 +4,7 @@
 # RUN: %revngcliftopt /dev/null --import-model-types="import-all model=%s" | FileCheck %s
 
 Types:
-  # CHECK: #my_struct = #clift.struct<
+  # CHECK: #my_struct$def = #clift.struct<
   # CHECK:   id = 1001
   # CHECK:   name = "my_struct"
   # CHECK:   size = 4
@@ -21,7 +21,7 @@ Types:
   # CHECK:     >
   # CHECK:   ]
   # CHECK: >
-  # CHECK: !my_struct1 = !clift.defined<#my_struct>
+  # CHECK: !my_struct = !clift.defined<#my_struct$def>
   - ID: 1001
     Kind: StructType
     CustomName: "my_struct"

--- a/tests/unit/mlir_lit_tests/model-import/StructType.yml
+++ b/tests/unit/mlir_lit_tests/model-import/StructType.yml
@@ -17,7 +17,7 @@ Types:
     PrimitiveKind: Unsigned
     Size: 4
 
-    # CHECK: #my_struct = #clift.struct<
+    # CHECK: #my_struct$def = #clift.struct<
     # CHECK:   id = 1001
     # CHECK:   name = "my_struct"
     # CHECK:   size = 8
@@ -36,7 +36,7 @@ Types:
     # CHECK:     >
     # CHECK:   ]
     # CHECK: >
-    # CHECK: !my_struct1 = !clift.defined<#my_struct>
+    # CHECK: !my_struct = !clift.defined<#my_struct$def>
   - ID: 1001
     Kind: StructType
     CustomName: "my_struct"

--- a/tests/unit/mlir_lit_tests/model-import/TypedefType.yml
+++ b/tests/unit/mlir_lit_tests/model-import/TypedefType.yml
@@ -9,12 +9,12 @@ Types:
     PrimitiveKind: Unsigned
     Size: 4
 
-    # CHECK:  #my_typedef = #clift.typedef<
+    # CHECK:  #my_typedef$def = #clift.typedef<
     # CHECK:    id = 1001
     # CHECK:    name = "my_typedef"
     # CHECK:    underlying_type = !uint32_t
     # CHECK:  >
-    # CHECK:  !my_typedef1 = !clift.defined<#my_typedef>
+    # CHECK:  !my_typedef = !clift.defined<#my_typedef$def>
   - ID: 1001
     Kind: TypedefType
     CustomName: "my_typedef"

--- a/tests/unit/mlir_lit_tests/model-import/UnionType.yml
+++ b/tests/unit/mlir_lit_tests/model-import/UnionType.yml
@@ -17,7 +17,7 @@ Types:
     PrimitiveKind: Unsigned
     Size: 4
 
-    # CHECK: #my_union = #clift.union<
+    # CHECK: #my_union$def = #clift.union<
     # CHECK:   id = 1001
     # CHECK:   name = "my_union"
     # CHECK:   fields = [
@@ -35,7 +35,7 @@ Types:
     # CHECK:     >
     # CHECK:   ]
     # CHECK: >
-    # CHECK: !my_union1 = !clift.defined<#my_union>
+    # CHECK: !my_union = !clift.defined<#my_union$def>
   - ID: 1001
     Kind: UnionType
     CustomName: "my_union"


### PR DESCRIPTION
Various Clift cleanup.
* Replaced many uses of `Type` with `ValueType`.
* Renamed `TypeDefinition` to `TypeDefinitionAttr` and made the naming of the derived classes consistent following the pattern `StructTypeAttr`.
* Added the `Clift_` prefix to tablegen definitions where it was missing.
* Changed Clift alias attribute and type alias generation to be more structured. This uses the `$` character as a special marker. E.g. `my_struct$def` for `StructTypeAttr` alias, `my_struct` for the corresponding `DefinedType` and `my_struct$const` for its const-qualified version.
* Reorganised function definitions in `CliftAttributes.cpp` and `CliftTypes.cpp`.