### PR TITLE
BundleEdgesByCycle: implement transformation pass

### DIFF
--- a/include/revng-c/RestructureCFG/BundleEdgesByCycle.h
+++ b/include/revng-c/RestructureCFG/BundleEdgesByCycle.h
@@ -1,0 +1,20 @@
+#pragma once
+
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include "llvm/IR/Function.h"
+#include "llvm/Pass.h"
+
+class BundleEdgesByCyclePass : public llvm::FunctionPass {
+public:
+  static char ID;
+
+public:
+  BundleEdgesByCyclePass() : llvm::FunctionPass(ID) {}
+
+  bool runOnFunction(llvm::Function &F) override;
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+};

--- a/lib/RestructureCFG/BundleEdgesByCycle.cpp
+++ b/lib/RestructureCFG/BundleEdgesByCycle.cpp
@@ -1,0 +1,223 @@
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include "llvm/IR/IRBuilder.h"
+
+#include "revng/Support/Assert.h"
+
+#include "revng-c/RestructureCFG/BundleEdgesByCycle.h"
+#include "revng-c/RestructureCFG/CycleEquivalenceAnalysis.h"
+#include "revng-c/RestructureCFG/CycleEquivalencePass.h"
+
+char BundleEdgesByCyclePass::ID = 0;
+
+static constexpr const char *Flag = "bundle-edges-by-cycle";
+using Reg = llvm::RegisterPass<BundleEdgesByCyclePass>;
+static Reg X(Flag, "Bundle Edges by Cycle Equivalence Class ID");
+
+using namespace llvm;
+
+class BundleEdgesByCycleImpl {
+private:
+  // This `enum class` is used to specialize the code in the `connectDispatcher`
+  // helper function
+  enum class DispatcherTy {
+    IncomingDispatcher,
+    OutgoingDispatcher,
+  };
+
+public:
+  using CER = CycleEquivalenceAnalysis<Function *>::CycleEquivalenceResult;
+
+private:
+  CER &CycleEquivalenceResult;
+
+public:
+  BundleEdgesByCycleImpl(CER &CycleEquivalenceResult) :
+    CycleEquivalenceResult(CycleEquivalenceResult) {}
+
+  void run(llvm::Function &F) {
+    // We save the postorder, since we insert new blocks during the
+    // transformation, and we may invalidate the `llvm::post_order`
+    llvm::SmallVector<BasicBlock *> InitialPostOrder;
+    for (BasicBlock *BB : post_order(&F)) {
+      InitialPostOrder.push_back(BB);
+    }
+
+    // We iterate over the `BasicBlock`s in the function according
+    for (BasicBlock *BB : InitialPostOrder) {
+
+      // For each node, we divide the predecessor edges, if they belong to
+      // different `Cycle Equivalence Class ID`s, so that they are grouped into
+      // different entry nodes
+      std::map<size_t, BasicBlock *> CECIDToBlockPredecessorMap;
+
+      llvm::SmallVector<BasicBlock *> Predecessors;
+      for (BasicBlock *Predecessor : predecessors(BB)) {
+        Predecessors.push_back(Predecessor);
+      }
+
+      for (BasicBlock *Predecessor : Predecessors) {
+
+        // In order to retrieve the `Cycle Equivalence Class ID`, we need the
+        // know the successor index (the index of the edge we are moving,
+        // relative to its source node). For this reason, we need to perform the
+        // moving of the edge with an exploration which starts from each
+        // `Predecessor` of the `BB` node.
+        llvm::SmallVector<BasicBlock *> Successors;
+        for (BasicBlock *Successor : successors(Predecessor)) {
+          Successors.push_back(Successor);
+        }
+
+        for (const auto &[Index, Successor] : llvm::enumerate(Successors)) {
+
+          // We are only interested in moving edges reaching the `BB` block in
+          // each iteration. The complete iteration is used and necessary just
+          // in order to keep track of the `Index` value (which is an integral
+          // part of how we query the `CycleEquivalenceResult` mapping).
+          if (Successor != BB) {
+            continue;
+          }
+
+          using DispatcherTy::IncomingDispatcher;
+          connectDispatcher<IncomingDispatcher>(Predecessor,
+                                                BB,
+                                                Index,
+                                                CECIDToBlockPredecessorMap);
+        }
+      }
+
+      // For each node, we divide the successor edges, if they belong to
+      // different `Cycle Equivalence Class ID`s, so that they are grouped into
+      // different exit nodes
+      std::map<size_t, BasicBlock *> CECIDToBlockSuccessorMap;
+
+      llvm::SmallVector<BasicBlock *> Successors;
+      for (BasicBlock *Successor : successors(BB)) {
+        Successors.push_back(Successor);
+      }
+
+      for (const auto &[Index, Successor] : llvm::enumerate(Successors)) {
+        using DispatcherTy::OutgoingDispatcher;
+        connectDispatcher<OutgoingDispatcher>(BB,
+                                              Successor,
+                                              Index,
+                                              CECIDToBlockSuccessorMap);
+      }
+    }
+  }
+
+  /// This helper function is responsible of inserting a new `Dispatcher` block
+  /// by splitting the edge between the `Source` block (with the n-th successor
+  /// edge identified with the `Index` parameter) and the `Target` block, with
+  /// the goal of grouping the edges by `Cycle Equivalence Class ID`
+  template<DispatcherTy DispatcherType>
+  void connectDispatcher(BasicBlock *Source,
+                         BasicBlock *Target,
+                         size_t Index,
+                         std::map<size_t, BasicBlock *>
+                           &CycleEquivalenceClassIDToBlockEdgeMap) {
+    using CER = CycleEquivalenceAnalysis<Function *>::CycleEquivalenceResult;
+    using EdgeDescriptor = CER::EdgeDescriptor;
+
+    BasicBlock *Dispatcher = nullptr;
+
+    // The successor `Index` is fundamental in order to query the
+    // `CycleEquivalenceResult` map, in order to disambiguate between edges
+    // insisting between the same node pair
+    auto Edge = EdgeDescriptor({ Source, Target, Index });
+    size_t EdgeID = CycleEquivalenceResult.getCycleEquivalenceClassID(Edge);
+
+    // We verify if we already have a dispatcher block for a certain `cycle
+    // equivalence class ID`, and, if not, in case we materialize one
+    auto It = CycleEquivalenceClassIDToBlockEdgeMap.find(EdgeID);
+    if (It != CycleEquivalenceClassIDToBlockEdgeMap.end()) {
+      Dispatcher = It->second;
+
+      if (DispatcherType == DispatcherTy::OutgoingDispatcher) {
+
+        // When using an already created `OutgoingDispatcher`, we assert that
+        // the unique successor it has been connected to when the `Dispatcher`
+        // was created, is the same block target of the outgoing edge we are
+        // currently redirecting to it, in order to preserve the original
+        // semantics of the control flow. By construction `OutgoingDispatcher`
+        // has a unique successor. A violation of this condition does not mean
+        // that it is impossible to perform this transformation (we would need
+        // to additionally group the outgoing edges both by `Cycle Equivalence
+        // Class ID` and reached successors), but due to our understanding of
+        // cycle equivalence, this should never happen.
+        auto *OriginalSuccessor = Dispatcher->getUniqueSuccessor();
+        revng_assert(OriginalSuccessor == Target);
+      }
+    } else {
+
+      // We create a new dedicated dispatcher block for grouping all the
+      // edges belonging to a specific `Cycle Equivalence Class ID`. We add
+      // to the block name as a suffix the `Cycle Equivalence Class ID`.
+      size_t ClassIndex = EdgeID;
+
+      // Depending on whether we are inserting an incoming or outgoing
+      // dispatcher block, we specialize the code
+      if constexpr (DispatcherType == DispatcherTy::IncomingDispatcher) {
+        Dispatcher = BasicBlock::Create(Target->getContext(),
+                                        Target->getName() + "_pred_ceci_"
+                                          + std::to_string(ClassIndex),
+                                        Target->getParent());
+      } else if (DispatcherType == DispatcherTy::OutgoingDispatcher) {
+        Dispatcher = BasicBlock::Create(Source->getContext(),
+                                        Source->getName() + "_succ_ceci_"
+                                          + std::to_string(ClassIndex),
+                                        Source->getParent());
+      } else {
+        revng_abort();
+      }
+
+      // We connect the new dispatcher `BasicBlock` to the `Target` block
+      IRBuilder<> Builder(Source->getParent()->getContext());
+      Builder.SetInsertPoint(Dispatcher);
+      Builder.CreateBr(Target);
+
+      // Assign the `Cycle Equivalence Class ID` for the new edge.
+      // `SuccNum` is by construction 0 (the inserted edge is the first and
+      // only successor edge for the `IncomingDispatcher` block).
+      CycleEquivalenceResult.insert(EdgeDescriptor(Dispatcher, Target, 0),
+                                    EdgeID);
+
+      // Populate the `CycleEquivalenceClassID` to the `Dispatcher`
+      // mapping
+      CycleEquivalenceClassIDToBlockEdgeMap[EdgeID] = Dispatcher;
+    }
+
+    // Connect the `Source` block to the `Dispatcher` block instead of the
+    // `Target` block. We explicitly keep track of the edge `Index` of the edge
+    // we are splitting during the outermost iteration, so we can use it to
+    // populate the `CycleEquivalenceResult` mapping.
+    llvm::Instruction *Terminator = Source->getTerminator();
+    Terminator->setSuccessor(Index, Dispatcher);
+    CycleEquivalenceResult.insert(EdgeDescriptor(Source, Dispatcher, Index),
+                                  EdgeID);
+  }
+};
+
+bool BundleEdgesByCyclePass::runOnFunction(llvm::Function &F) {
+
+  // We need to obtain a copy of the `CycleEquivalenceResult`, because in this
+  // pass we need to insert the mapping for the additional edges that we
+  // introduce during the transformation
+  using CER = BundleEdgesByCycleImpl::CER;
+  CER CycleEquivalenceResult = getAnalysis<CycleEquivalencePass>().getResult();
+
+  BundleEdgesByCycleImpl Impl(CycleEquivalenceResult);
+  Impl.run(F);
+
+  // This pass modifies the module, adding predecessors and successors to the
+  // nodes
+  return true;
+}
+
+void BundleEdgesByCyclePass::getAnalysisUsage(llvm::AnalysisUsage &AU) const {
+
+  // This pass depends on the `Cycle Equivalence` analysis
+  AU.addRequired<CycleEquivalencePass>();
+}

--- a/lib/RestructureCFG/CMakeLists.txt
+++ b/lib/RestructureCFG/CMakeLists.txt
@@ -10,6 +10,7 @@ revng_add_analyses_library(
   ASTTree.cpp
   BasicBlockNode.cpp
   BeautifyGHAST.cpp
+  BundleEdgesByCycle.cpp
   CycleEquivalenceAnalysis.cpp
   CycleEquivalencePass.cpp
   ExprNode.cpp

--- a/tests/unit/llvm_lit_tests/BundleEdgesByCycle.ll
+++ b/tests/unit/llvm_lit_tests/BundleEdgesByCycle.ll
@@ -1,0 +1,424 @@
+;
+; Copyright rev.ng Labs Srl. See LICENSE.md for details.
+;
+
+; RUN: %revngopt %s -bundle-edges-by-cycle -S -o - |& FileCheck %s
+
+; while test
+
+define void @f() {
+entry:
+  br label %while.cond
+
+while.cond:
+  br i1 undef, label %while.body, label %while.end
+
+while.body:
+  br label %while.cond
+
+while.end:
+  ret void
+}
+
+; CHECK-LABEL: void @f
+
+; CHECK: entry:
+; CHECK:  br label %entry_succ_ceci_1
+
+; CHECK: while.cond:
+; CHECK:  br i1 undef, label %while.cond_succ_ceci_0, label %while.cond_succ_ceci_1
+
+; CHECK: while.body:
+; CHECK:   br label %while.body_succ_ceci_0
+
+; CHECK: while.end:
+; CHECK:   ret void
+
+; CHECK: while.body_pred_ceci_0:
+; CHECK:   br label %while.body
+
+; CHECK: while.body_succ_ceci_0:
+; CHECK:   br label %while.cond_pred_ceci_0
+
+; CHECK: while.end_pred_ceci_1:
+; CHECK:   br label %while.end
+
+; CHECK: while.cond_pred_ceci_0:
+
+; CHECK: while.cond_pred_ceci_1:
+; CHECK:   br label %while.cond
+
+; CHECK: while.cond_succ_ceci_0:
+; CHECK:   br label %while.body_pred_ceci_0
+
+; CHECK: while.cond_succ_ceci_1:
+; CHECK:   br label %while.end_pred_ceci_1
+
+; CHECK: entry_succ_ceci_1:
+; CHECK:   br label %while.cond_pred_ceci_1
+
+; nested whiles test
+
+define void @g() {
+entry:
+  br label %while.cond
+
+while.cond:
+  br i1 undef, label %while.body, label %while.end6
+
+while.body:
+  br label %while.cond1
+
+while.cond1:
+  br i1 undef, label %while.body3, label %while.end
+
+while.body3:
+  br label %while.cond1
+
+while.end:
+  br label %while.cond
+
+while.end6:
+  ret void
+}
+
+; CHECK-LABEL: void @g
+
+; CHECK: entry:
+; CHECK:   br label %entry_succ_ceci_2
+
+; CHECK: while.cond:
+; CHECK:   br i1 undef, label %while.cond_succ_ceci_1, label %while.cond_succ_ceci_2
+
+; CHECK: while.body:
+; CHECK:   br label %while.body_succ_ceci_1
+
+; CHECK: while.cond1:
+; CHECK:   br i1 undef, label %while.cond1_succ_ceci_0, label %while.cond1_succ_ceci_1
+
+; CHECK: while.body3:
+; CHECK:   br label %while.body3_succ_ceci_0
+
+; CHECK: while.end:
+; CHECK:   br label %while.end_succ_ceci_1
+
+; CHECK: while.end6:
+; CHECK:   ret void
+
+; CHECK: while.body3_pred_ceci_0:
+; CHECK:   br label %while.body3
+
+; CHECK: while.body3_succ_ceci_0:
+; CHECK:   br label %while.cond1_pred_ceci_0
+
+; CHECK: while.end_pred_ceci_1:
+; CHECK:   br label %while.end
+
+; CHECK: while.end_succ_ceci_1:
+; CHECK:   br label %while.cond_pred_ceci_1
+
+; CHECK: while.cond1_pred_ceci_0:
+; CHECK:   br label %while.cond1
+
+; CHECK: while.cond1_pred_ceci_1:
+; CHECK:   br label %while.cond1
+
+; CHECK: while.cond1_succ_ceci_0:
+; CHECK:   br label %while.body3_pred_ceci_0
+
+; CHECK: while.cond1_succ_ceci_1:
+; CHECK:   br label %while.end_pred_ceci_1
+
+; CHECK: while.body_pred_ceci_1:
+; CHECK:   br label %while.body
+
+; CHECK: while.body_succ_ceci_1:
+; CHECK:   br label %while.cond1_pred_ceci_1
+
+; CHECK: while.end6_pred_ceci_2:
+; CHECK:   br label %while.end6
+
+; CHECK: while.cond_pred_ceci_1:
+; CHECK:   br label %while.cond
+
+; CHECK: while.cond_pred_ceci_2:
+; CHECK:   br label %while.cond
+
+; CHECK: while.cond_succ_ceci_1:
+; CHECK:   br label %while.body_pred_ceci_1
+
+; CHECK: while.cond_succ_ceci_2:
+; CHECK:   br label %while.end6_pred_ceci_2
+
+; CHECK: entry_succ_ceci_2:
+; CHECK:   br label %while.cond_pred_ceci_2
+
+; overlapping cycles test
+
+define void @h() {
+entry:
+  br label %while.cond
+
+while.cond:
+  br i1 undef, label %while.body, label %while.end
+
+while.body:
+  br label %label
+
+label:
+  br i1 undef, label %if.then, label %if.end
+
+if.then:
+  br label %while.cond
+
+if.end:
+  br i1 undef, label %if.then4, label %if.end5
+
+if.then4:
+  br label %label
+
+if.end5:
+  br label %while.cond
+
+while.end:
+  ret void
+}
+
+; CHECK-LABEL: void @h
+
+; CHECK: entry:
+; CHECK:   br label %entry_succ_ceci_5
+
+; CHECK: while.cond:
+; CHECK:   br i1 undef, label %while.cond_succ_ceci_4, label %while.cond_succ_ceci_5
+
+; CHECK: while.body:
+; CHECK:   br label %while.body_succ_ceci_4
+
+; CHECK: label:
+; CHECK:   br i1 undef, label %label_succ_ceci_0, label %label_succ_ceci_3
+
+; CHECK: if.then:
+; CHECK:   br label %if.then_succ_ceci_0
+
+; CHECK: if.end:
+; CHECK:   br i1 undef, label %if.end_succ_ceci_1, label %if.end_succ_ceci_2
+
+; CHECK: if.then4:
+; CHECK:   br label %if.then4_succ_ceci_1
+
+; CHECK: if.end5:
+; CHECK:   br label %if.end5_succ_ceci_2
+
+; CHECK: while.end:
+; CHECK:   ret void
+
+; CHECK: if.then_pred_ceci_0:
+; CHECK:   br label %if.then
+
+; CHECK: if.then_succ_ceci_0:
+; CHECK:   br label %while.cond_pred_ceci_0
+
+; CHECK: if.then4_pred_ceci_1:
+; CHECK:   br label %if.then4
+
+; CHECK: if.then4_succ_ceci_1:
+; CHECK:   br label %label_pred_ceci_1
+
+; CHECK: if.end5_pred_ceci_2:
+; CHECK:   br label %if.end5
+
+; CHECK: if.end5_succ_ceci_2:
+; CHECK:   br label %while.cond_pred_ceci_2
+
+; CHECK: if.end_pred_ceci_3:
+; CHECK:   br label %if.end
+
+; CHECK: if.end_succ_ceci_1:
+; CHECK:   br label %if.then4_pred_ceci_1
+
+; CHECK: if.end_succ_ceci_2:
+; CHECK:   br label %if.end5_pred_ceci_2
+
+; CHECK: label_pred_ceci_1:
+; CHECK:   br label %label
+
+; CHECK: label_pred_ceci_4:
+; CHECK:   br label %label
+
+; CHECK: label_succ_ceci_0:
+; CHECK:   br label %if.then_pred_ceci_0
+
+; CHECK: label_succ_ceci_3:
+; CHECK:   br label %if.end_pred_ceci_3
+
+; CHECK: while.body_pred_ceci_4:
+; CHECK:   br label %while.body
+
+; CHECK: while.body_succ_ceci_4:
+; CHECK:   br label %label_pred_ceci_4
+
+; CHECK: while.end_pred_ceci_5:
+; CHECK:   br label %while.end
+
+; CHECK: while.cond_pred_ceci_2:
+; CHECK:   br label %while.cond
+
+; CHECK: while.cond_pred_ceci_0:
+; CHECK:   br label %while.cond
+
+; CHECK: while.cond_pred_ceci_5:
+; CHECK:   br label %while.cond
+
+; CHECK: while.cond_succ_ceci_4:
+; CHECK:   br label %while.body_pred_ceci_4
+
+; CHECK: while.cond_succ_ceci_5:
+; CHECK:   br label %while.end_pred_ceci_5
+
+; CHECK: entry_succ_ceci_5:
+; CHECK:   br label %while.cond_pred_ceci_5
+
+; diamond test
+
+define void @i() {
+entry:
+  br i1 undef, label %if.then, label %if.else
+
+if.then:
+  br label %if.end
+
+if.else:
+  br label %if.end
+
+if.end:
+  ret void
+}
+
+; CHECK-LABEL: void @i
+
+; CHECK: entry:
+; CHECK:   br i1 undef, label %entry_succ_ceci_1, label %entry_succ_ceci_0
+
+; CHECK: if.then:
+; CHECK:   br label %if.then_succ_ceci_1
+
+; CHECK: if.else:
+; CHECK:   br label %if.else_succ_ceci_0
+
+; CHECK: if.end:
+; CHECK:   ret void
+
+; CHECK: if.end_pred_ceci_0:
+; CHECK:   br label %if.end
+
+; CHECK: if.end_pred_ceci_1:
+; CHECK:   br label %if.end
+
+; CHECK: if.then_pred_ceci_1:
+; CHECK:   br label %if.then
+
+; CHECK: if.then_succ_ceci_1:
+; CHECK:   br label %if.end_pred_ceci_1
+
+; CHECK: if.else_pred_ceci_0:
+; CHECK:   br label %if.else
+
+; CHECK: if.else_succ_ceci_0:
+; CHECK:   br label %if.end_pred_ceci_0
+
+; CHECK: entry_succ_ceci_1:
+; CHECK:   br label %if.then_pred_ceci_1
+
+; CHECK: entry_succ_ceci_0:
+; CHECK:   br label %if.else_pred_ceci_0
+
+; double edge test
+
+define void @l() {
+block_a:
+  br i1 undef, label %block_b, label %block_b
+
+block_b:
+  ret void
+}
+
+; CHECK-LABEL: void @l
+
+; CHECK: block_a:
+; CHECK:   br i1 undef, label %block_a_succ_ceci_1, label %block_a_succ_ceci_0
+
+; CHECK: block_b:
+; CHECK:   ret void
+
+; CHECK: block_b_pred_ceci_1:
+; CHECK:   br label %block_b
+
+; CHECK: block_b_pred_ceci_0:
+; CHECK:   br label %block_b
+
+; CHECK: block_a_succ_ceci_1:
+; CHECK:   br label %block_b_pred_ceci_1
+
+; CHECK: block_a_succ_ceci_0:
+; CHECK:   br label %block_b_pred_ceci_0
+
+; while self-loop test
+
+define void @m() {
+entry:
+  br label %while.cond
+
+while.cond:
+  br i1 undef, label %while.body, label %while.end
+
+while.body:
+  br i1 undef, label %while.cond, label %while.body
+
+while.end:
+  ret void
+}
+
+; CHECK-LABEL: void @m
+
+; CHECK: entry:
+; CHECK:   br label %entry_succ_ceci_2
+
+; CHECK: while.cond:
+; CHECK:   br i1 undef, label %while.cond_succ_ceci_0, label %while.cond_succ_ceci_2
+
+; CHECK: while.body:
+; CHECK:   br i1 undef, label %while.body_succ_ceci_0, label %while.body_succ_ceci_1
+
+; CHECK: while.end:
+; CHECK:   ret void
+
+; CHECK: while.body_pred_ceci_1:
+; CHECK:   br label %while.body
+
+; CHECK: while.body_pred_ceci_0:
+; CHECK:   br label %while.body
+
+; CHECK: while.body_succ_ceci_0:
+; CHECK:   br label %while.cond_pred_ceci_0
+
+; CHECK: while.body_succ_ceci_1:
+; CHECK:   br label %while.body_pred_ceci_1
+
+; CHECK: while.end_pred_ceci_2:
+; CHECK:   br label %while.end
+
+; CHECK: while.cond_pred_ceci_0:
+; CHECK:   br label %while.cond
+
+; CHECK: while.cond_pred_ceci_2:
+; CHECK:   br label %while.cond
+
+; CHECK: while.cond_succ_ceci_0:
+; CHECK:   br label %while.body_pred_ceci_0
+
+; CHECK: while.cond_succ_ceci_2:
+; CHECK:   br label %while.end_pred_ceci_2
+
+; CHECK: entry_succ_ceci_2:
+; CHECK:   br label %while.cond_pred_ceci_2


### PR DESCRIPTION
We implement the `BundleEdgesByCycle` LLVMIR transformation pass.

The goal of this transformation is to introduce an header and sink for each node in the graph, in order to enforce the following properties:
- We group the edges incoming into a node, on the basis of the cycle equivalence class. All the edges belonging to the same class, will be grouped as incoming of a new header, which will be in turn connected to the original node.
- We group the edges outgoing from a node, on the basis of the cycle equivalence class. All the edges belonging to the same class, will be grouped as incoming of a new sink node, which will be in turn connected to the original successor.

The goal of this transformation pass is to pre-process the input graph before the `GenericRegionInfo` analysis is run, in order to improve the distinction of different regions.
`GenericRegionInfo` indeed, has a node granularity, and inserting the additional headers and sinks enables us to normalize the graph, by inserting additional nodes for each group of edges that belong to the same cycle equivalence class, and virtually computing the results of the analysis with a _edge_ granularity.

We add some unit tests to check the functionality of this pass.